### PR TITLE
Add MAC-aware DHCP lease handling

### DIFF
--- a/src/tools/wifi.ts
+++ b/src/tools/wifi.ts
@@ -129,7 +129,7 @@ export function registerWifiTools(
 
         if (reached && dhcpManager) {
           // Connection successful, get IP address via DHCP
-          await dhcpManager.start(targetIface);
+          await dhcpManager.start(targetIface, macConfig?.mode);
           const ipAddress = await dhcpManager.waitForIp(10000);
 
           return {
@@ -266,7 +266,7 @@ export function registerWifiTools(
 
         if (reached && dhcpManager) {
           // Connection successful, get IP address via DHCP
-          await dhcpManager.start(targetIface);
+          await dhcpManager.start(targetIface, macConfig?.mode);
           const ipAddress = await dhcpManager.waitForIp(10000);
 
           return {


### PR DESCRIPTION
## Summary

- When `mac_mode` is `random` or `persistent-random`, use `dhclient -lf /dev/null` to force fresh DHCP discovery
- Prevents dhclient from requesting cached IP when MAC address has changed
- Ensures different random MACs get different IP addresses

## Problem

Previously, dhclient cached leases by interface name (not MAC). When connecting with random MAC addresses, dhclient would read `/var/lib/dhclient/dhclient.leases` and request the same IP it had before, regardless of the new MAC address.

## Solution

Pass `macMode` from wifi connection tools to `DhcpManager.start()`. When MAC randomization is enabled, add `-lf /dev/null` flag to dhclient to skip lease file caching.

## Changes

| File | Change |
|------|--------|
| `src/lib/dhcp-manager.ts` | Add optional `macMode` parameter, conditionally use `-lf /dev/null` |
| `src/tools/wifi.ts` | Pass `macConfig?.mode` to `dhcpManager.start()` |

## MAC Mode Behavior

| mac_mode | DHCP Behavior |
|----------|---------------|
| `undefined` | Use cached lease (backward compatible) |
| `device` | Use cached lease (same real MAC) |
| `random` | Fresh DHCP discovery (new IP) |
| `persistent-random` | Fresh DHCP discovery (new IP) |
| `specific` | Use cached lease (user controls MAC) |

## Test Results

| Test | MAC Address | IP Address |
|------|-------------|------------|
| Before fix | Different MACs | Always 192.168.5.154 |
| After fix #1 | 06:7a:e3:b1:a7:dc | 192.168.5.157 |
| After fix #2 | be:5a:3b:55:e5:be | 192.168.5.156 |
| After fix #3 | 76:55:67:d7:dd:ec | 192.168.5.159 |

🤖 Generated with [Claude Code](https://claude.ai/code)