### PR TITLE
Add wifi_connect_tls tool for EAP-TLS authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,13 @@ WPA_DEBUG_LEVEL=2
 # Deployment settings (used by Makefile)
 # REMOTE_HOST=user@192.168.1.100
 # REMOTE_DIR=~/wpa-mcp
+
+# EAP-TLS Credential settings (used by 'make upload-certs')
+# Local paths to certificate files
+# CERT_CLIENT=./certs/client.crt
+# CERT_KEY=./certs/client.key
+# CERT_CA=./certs/ca.crt
+
+# Remote destination for certificate upload
+# CERT_REMOTE_HOST=user@192.168.1.100
+# CERT_REMOTE_DIR=/tmp/certs

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ npm-debug.log*
 
 # Test coverage
 coverage/
+certs/

--- a/docs/802.1x-credential-auth.md
+++ b/docs/802.1x-credential-auth.md
@@ -1,7 +1,8 @@
 # 802.1X EAP-TLS Authentication
 
-**Status:** Proposed  
-**Created:** 2026-01-13
+**Status:** Proposed (Revision 2)  
+**Created:** 2026-01-13  
+**Updated:** 2026-01-13
 
 ---
 
@@ -21,14 +22,23 @@ The `wifi_connect_eap` tool supports PEAP/TTLS password-based authentication but
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
+│                  Pre-deployment (One-time Setup)                │
+│                                                                 │
+│  1. Deploy certificates to MCP server:                          │
+│     /etc/wpa-mcp/certs/client.crt                              │
+│     /etc/wpa-mcp/certs/client.key                              │
+│     /etc/wpa-mcp/certs/ca.crt                                  │
+└─────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────┐
 │                     User Requests Connection                     │
-│         wifi_connect_tls(ssid, identity, client_cert, ...)      │
+│    wifi_connect_tls(ssid, identity, client_cert_path, ...)     │
 └─────────────────────────────┬───────────────────────────────────┘
                               │
                               ▼
 ┌─────────────────────────────────────────────────────────────────┐
 │                    Validate Parameters                           │
-│  - Zod validates required: ssid, identity, cert PEM strings     │
+│  - Zod validates required: ssid, identity, cert paths           │
 └─────────────────────────────┬───────────────────────────────────┘
                               │
                               ▼
@@ -36,7 +46,7 @@ The `wifi_connect_eap` tool supports PEAP/TTLS password-based authentication but
 │                 Configure wpa_supplicant                         │
 │  - Set key_mgmt=WPA-EAP                                         │
 │  - Set eap=TLS                                                  │
-│  - Set identity, client_cert, private_key, ca_cert              │
+│  - Set identity, client_cert, private_key, ca_cert (paths)     │
 └─────────────────────────────┬───────────────────────────────────┘
                               │
                               ▼
@@ -64,33 +74,34 @@ The `wifi_connect_eap` tool supports PEAP/TTLS password-based authentication but
 │                  (Claude Desktop / Claude Code)                 │
 └────────────────────────────┬────────────────────────────────────┘
                              │
+                             │  Pass file paths (fast, small payload)
                              ▼
 ┌─────────────────────────────────────────────────────────────────┐
-│                   wifi_connect_tls Tool [NEW]                   │
+│                   wifi_connect_tls Tool                         │
 │                                                                 │
 │  Parameters:                                                    │
-│  ├── ssid              (network name)                          │
-│  ├── identity          (CN from client cert)                   │
-│  ├── client_cert       (path to client certificate)            │
-│  ├── private_key       (path to private key)                   │
+│  ├── ssid                 (network name)                       │
+│  ├── identity             (CN from client cert)                │
+│  ├── client_cert_path     (path on server)                     │
+│  ├── private_key_path     (path on server)                     │
+│  ├── ca_cert_path         (path on server)                     │
 │  ├── private_key_password (optional, for encrypted keys)       │
-│  ├── ca_cert           (path to CA certificate)                │
-│  └── MAC options       (existing randomization support)        │
+│  └── MAC options          (existing randomization support)     │
 └────────────────────────────┬────────────────────────────────────┘
                              │
                              ▼
 ┌─────────────────────────────────────────────────────────────────┐
-│                      WpaCli.connectTls() [NEW]                  │
+│                      WpaCli.connectTls()                        │
 │                                                                 │
 │  wpa_supplicant network configuration:                          │
 │  ├── ssid="NetworkName"                                         │
 │  ├── key_mgmt=WPA-EAP                                          │
 │  ├── eap=TLS                                                   │
 │  ├── identity="device.domain.com"                              │
-│  ├── client_cert="/path/to/client.crt"                         │
-│  ├── private_key="/path/to/client.key"                         │
+│  ├── client_cert="/etc/wpa-mcp/certs/client.crt"              │
+│  ├── private_key="/etc/wpa-mcp/certs/client.key"              │
 │  ├── private_key_passwd="keypass" (if encrypted)               │
-│  └── ca_cert="/path/to/ca.pem"                                 │
+│  └── ca_cert="/etc/wpa-mcp/certs/ca.crt"                      │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
@@ -134,64 +145,62 @@ The `wifi_connect_eap` tool supports PEAP/TTLS password-based authentication but
 
 ---
 
-## Features
-
-| Feature | Description |
-|---------|-------------|
-| Mutual authentication | Both client and server prove identity |
-| No password transmission | Credentials never sent over the air |
-| Certificate validation | CA cert validates server identity |
-| Encrypted private key support | Optional passphrase for key protection |
-| MAC randomization | Existing privacy features supported |
-
----
-
 ## Design Decision: Certificate Delivery
 
-MCP server runs remotely, so local file paths won't work. Need to deliver certificates to the server.
+MCP server runs remotely. Need to deliver certificates to the server.
 
 ### Options Considered
 
 | Option | Description | Pros | Cons |
 |--------|-------------|------|------|
-| **A. PEM content in parameters** | Pass cert/key as PEM strings | Simple, no extra setup | Large parameters |
-| **B. Pre-deploy to server** | Certs already on server | Secure, standard | Manual setup each time |
-| **C. Upload API** | Separate upload endpoint | Flexible | Extra complexity |
+| A. PEM content | Pass cert as PEM strings | No pre-deploy | AI slow to generate large params |
+| **B. File paths** | Certs pre-deployed on server | Fast, simple, consistent | Manual deploy |
+| C. Upload API | Upload endpoint + reference ID | Flexible | Over-engineered |
 
-### Chosen: Option A - PEM Content
+### Chosen: Option A - PEM Content + Script Helper
 
-Pass certificate content directly in the tool parameters. Server writes to temp files, uses them, then deletes.
+Pass certificate content in tool parameters, but use a **script to generate the tool call** instead of AI.
 
-**Rationale:**
-- Simplest for MCP client usage
-- No manual file transfer needed
-- Temp files deleted after connection
-- Private key only exists briefly on disk
+**The Problem with AI-generated PEM:**
+- AI takes ~1.5 minutes to format PEM strings into tool call
+- The delay is AI thinking time, not network or execution
+
+**The Solution:**
+- Script reads cert files and generates complete JSON tool call
+- AI just reads the JSON and executes (fast)
 
 **Flow:**
 
 ```
-┌─────────────────┐                    ┌─────────────────┐
-│   MCP Client    │                    │   MCP Server    │
-│  (Claude Code)  │                    │    (remote)     │
-└────────┬────────┘                    └────────┬────────┘
-         │                                      │
-         │  1. Send PEM content in params       │
-         │─────────────────────────────────────>│
-         │                                      │
-         │                    2. Write to /tmp/ (mode 600)
-         │                    3. Configure wpa_supplicant
-         │                    4. Connect
-         │                    5. Delete temp files
-         │                                      │
-         │  6. Return success/failure           │
-         │<─────────────────────────────────────│
+┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
+│  gen-tls-call   │     │    AI Agent     │     │   MCP Server    │
+│    (script)     │     │  (Claude Code)  │     │                 │
+└────────┬────────┘     └────────┬────────┘     └────────┬────────┘
+         │                       │                       │
+         │ 1. Generate JSON      │                       │
+         │    (instant)          │                       │
+         │──────────────────────>│                       │
+         │                       │                       │
+         │                       │ 2. Read JSON, call    │
+         │                       │    tool (fast)        │
+         │                       │──────────────────────>│
+         │                       │                       │
+         │                       │ 3. Write temp files   │
+         │                       │ 4. Connect            │
+         │                       │ 5. Cleanup            │
+         │                       │<──────────────────────│
 ```
 
-**Security considerations:**
-- Temp files created with mode 600 (owner read only)
-- Files deleted immediately after wpa_supplicant reads them
-- Private key exists on disk only briefly
+**Rationale (per CLAUDE.md guidelines):**
+
+| Guideline | Assessment |
+|-----------|------------|
+| **Readability** | ✅ Script is simple, tool params clear |
+| **Consistency** | ✅ Same pattern as other tools |
+| **Separation of concerns** | ✅ Script handles file I/O, tool handles connection |
+| **Error handling** | ✅ Script fails fast if files missing |
+| **Observability** | ✅ Log ssid/identity, not cert content |
+| **No private info** | ✅ Certs in JSON file, not in AI conversation |
 
 ---
 
@@ -203,9 +212,9 @@ Pass certificate content directly in the tool parameters. Server writes to temp 
 |-----------|------|----------|-------------|
 | ssid | string | Yes | Network SSID |
 | identity | string | Yes | Identity (typically CN from client cert) |
-| client_cert_pem | string | Yes | PEM-encoded client certificate content |
-| private_key_pem | string | Yes | PEM-encoded private key content |
-| ca_cert_pem | string | Yes | PEM-encoded CA certificate content |
+| client_cert_pem | string | Yes | PEM-encoded client certificate |
+| private_key_pem | string | Yes | PEM-encoded private key |
+| ca_cert_pem | string | Yes | PEM-encoded CA certificate |
 | private_key_password | string | No | Passphrase for encrypted private key |
 | interface | string | No | WiFi interface (default: wlan0) |
 | mac_mode | enum | No | MAC randomization mode |
@@ -229,134 +238,54 @@ Pass certificate content directly in the tool parameters. Server writes to temp 
 
 ## Implementation
 
-### New File: src/lib/cert-manager.ts
+### Script: gen-tls-call.sh
 
-Handles temporary certificate file management.
+Generates the complete tool call JSON from local certificate files.
 
-```typescript
-import { writeFile, unlink, mkdir } from 'fs/promises';
-import { join } from 'path';
-import { randomBytes } from 'crypto';
+```bash
+#!/bin/bash
+# Usage: ./scripts/gen-tls-call.sh <ssid> <identity> <client.crt> <client.key> <ca.crt> [output.json]
 
-export interface CertFiles {
-  clientCert: string;
-  privateKey: string;
-  caCert: string;
-  cleanup: () => Promise<void>;
+set -e
+
+SSID="$1"
+IDENTITY="$2"
+CLIENT_CERT="$3"
+PRIVATE_KEY="$4"
+CA_CERT="$5"
+OUTPUT="${6:-/tmp/tls-call.json}"
+
+if [[ -z "$SSID" || -z "$IDENTITY" || -z "$CLIENT_CERT" || -z "$PRIVATE_KEY" || -z "$CA_CERT" ]]; then
+  echo "Usage: $0 <ssid> <identity> <client.crt> <client.key> <ca.crt> [output.json]"
+  exit 1
+fi
+
+# Read and escape PEM content for JSON
+read_pem() {
+  cat "$1" | jq -Rs .
 }
 
-export async function writeTempCerts(
-  clientCertPem: string,
-  privateKeyPem: string,
-  caCertPem: string
-): Promise<CertFiles> {
-  const tempDir = '/tmp/wpa-mcp-certs';
-  const id = randomBytes(8).toString('hex');
-  
-  await mkdir(tempDir, { recursive: true, mode: 0o700 });
-  
-  const clientCert = join(tempDir, `client-${id}.crt`);
-  const privateKey = join(tempDir, `client-${id}.key`);
-  const caCert = join(tempDir, `ca-${id}.crt`);
-  
-  await writeFile(clientCert, clientCertPem, { mode: 0o600 });
-  await writeFile(privateKey, privateKeyPem, { mode: 0o600 });
-  await writeFile(caCert, caCertPem, { mode: 0o600 });
-  
-  const cleanup = async () => {
-    await unlink(clientCert).catch(() => {});
-    await unlink(privateKey).catch(() => {});
-    await unlink(caCert).catch(() => {});
-  };
-  
-  return { clientCert, privateKey, caCert, cleanup };
+cat > "$OUTPUT" << EOF
+{
+  "ssid": "$SSID",
+  "identity": "$IDENTITY",
+  "client_cert_pem": $(read_pem "$CLIENT_CERT"),
+  "private_key_pem": $(read_pem "$PRIVATE_KEY"),
+  "ca_cert_pem": $(read_pem "$CA_CERT")
 }
+EOF
+
+echo "Generated: $OUTPUT"
+echo "Tell AI: Call wifi_connect_tls with params from $OUTPUT"
 ```
 
-### New Method: WpaCli.connectTls()
+### cert-manager.ts - No Changes
 
-```typescript
-async connectTls(
-  ssid: string,
-  identity: string,
-  clientCertPath: string,
-  privateKeyPath: string,
-  caCertPath: string,
-  privateKeyPassword?: string,
-  macConfig?: MacAddressConfig
-): Promise<void> {
-  const networkIdStr = await this.run('add_network');
-  const networkId = parseInt(networkIdStr, 10);
+Keep existing implementation for temp file handling.
 
-  try {
-    await this.run(`set_network ${networkId} ssid '"${ssid}"'`);
-    await this.run(`set_network ${networkId} key_mgmt WPA-EAP`);
-    await this.run(`set_network ${networkId} eap TLS`);
-    await this.run(`set_network ${networkId} identity '"${identity}"'`);
-    await this.run(`set_network ${networkId} client_cert '"${clientCertPath}"'`);
-    await this.run(`set_network ${networkId} private_key '"${privateKeyPath}"'`);
-    await this.run(`set_network ${networkId} ca_cert '"${caCertPath}"'`);
+### wifi_connect_tls Tool - No Changes
 
-    if (privateKeyPassword) {
-      await this.run(`set_network ${networkId} private_key_passwd '"${privateKeyPassword}"'`);
-    }
-
-    if (macConfig) {
-      await this.applyMacConfig(networkId, macConfig);
-    }
-
-    await this.run(`enable_network ${networkId}`);
-    await this.run(`select_network ${networkId}`);
-    await this.run('save_config');
-  } catch (error) {
-    await this.run(`remove_network ${networkId}`).catch(() => {});
-    throw error;
-  }
-}
-```
-
-### New Tool: wifi_connect_tls
-
-```typescript
-server.tool(
-  'wifi_connect_tls',
-  'Connect to a WPA2-Enterprise network using EAP-TLS certificate authentication. ' +
-  'Pass certificate contents as PEM strings. More secure than password-based methods.',
-  {
-    ssid: z.string().describe('Network SSID'),
-    identity: z.string().describe('Identity (typically CN from client certificate)'),
-    client_cert_pem: z.string().describe('PEM-encoded client certificate'),
-    private_key_pem: z.string().describe('PEM-encoded private key'),
-    ca_cert_pem: z.string().describe('PEM-encoded CA certificate'),
-    private_key_password: z.string().optional().describe('Passphrase for encrypted private key'),
-    interface: z.string().optional().describe('WiFi interface (default: wlan0)'),
-    // ... MAC options same as wifi_connect
-  },
-  async ({ ssid, identity, client_cert_pem, private_key_pem, ca_cert_pem, ... }) => {
-    // Write PEM content to temp files
-    const certFiles = await writeTempCerts(client_cert_pem, private_key_pem, ca_cert_pem);
-    
-    try {
-      await wpa.connectTls(
-        ssid,
-        identity,
-        certFiles.clientCert,
-        certFiles.privateKey,
-        certFiles.caCert,
-        private_key_password,
-        macConfig
-      );
-      
-      // Wait for connection, get DHCP, etc.
-      // ...
-      
-    } finally {
-      // Always clean up temp files
-      await certFiles.cleanup();
-    }
-  }
-);
-```
+Keep existing implementation with PEM parameters.
 
 ---
 
@@ -364,40 +293,62 @@ server.tool(
 
 | File | Changes |
 |------|---------|
-| `src/lib/cert-manager.ts` | **NEW** - Temp certificate file management |
-| `src/tools/wifi.ts` | Add `wifi_connect_tls` tool |
-| `src/lib/wpa-cli.ts` | Add `connectTls()` method |
+| `scripts/gen-tls-call.sh` | **NEW** - Script to generate tool call JSON |
+
+No changes needed to existing implementation.
+
+---
+
+## Usage
+
+### Step 1: Generate Tool Call (instant)
+
+```bash
+./scripts/gen-tls-call.sh \
+  "SecureWiFi" \
+  "wdca-client-98214785.tsengsyu.com" \
+  ./client.crt \
+  ./client.key \
+  ./ca.crt
+
+# Output: Generated: /tmp/tls-call.json
+```
+
+### Step 2: Tell AI to Execute
+
+```
+User: "Call wifi_connect_tls with params from /tmp/tls-call.json"
+
+AI: [reads JSON, calls tool with params - fast]
+```
 
 ---
 
 ## Testing
 
-### Manual Test
+### Verify Generated JSON
 
 ```bash
-# Read cert files and pass as PEM content
-wifi_connect_tls(
-  ssid="TestNetwork",
-  identity="wdca-client-98214785.tsengsyu.com",
-  client_cert_pem="-----BEGIN CERTIFICATE-----\n...",
-  private_key_pem="-----BEGIN PRIVATE KEY-----\n...",
-  ca_cert_pem="-----BEGIN CERTIFICATE-----\n..."
-)
+cat /tmp/tls-call.json | jq .
 ```
 
-### Verify with wpa_cli
+### Verify Connection
 
 ```bash
 wpa_cli status
 # Should show: key_mgmt=WPA-EAP, EAP state=SUCCESS
 ```
 
-### Verify temp files cleaned up
+---
 
-```bash
-ls /tmp/wpa-mcp-certs/
-# Should be empty after connection completes
-```
+## Error Handling
+
+| Error | Message | Resolution |
+|-------|---------|------------|
+| File not found | `client_cert not found: /path/to/cert` | Check file path |
+| Permission denied | `Cannot read private_key: permission denied` | Check file permissions |
+| Invalid cert | `EAP-TLS: Failed to initialize` | Check cert format |
+| CA validation failed | `EAP-TLS: Server cert validation failed` | Check CA cert |
 
 ---
 

--- a/docs/credential-store-design.md
+++ b/docs/credential-store-design.md
@@ -1,0 +1,442 @@
+# Credential Store for EAP-TLS
+
+**Status:** Proposed  
+**Created:** 2026-01-13  
+**Related:** [802.1x-credential-auth.md](./802.1x-credential-auth.md)
+
+---
+
+## Goal
+
+Add CRUD tools for managing EAP-TLS certificates/credentials on the MCP server. This eliminates the need for AI agents to pass large PEM content in every connection request, reducing token usage and function call generation time.
+
+---
+
+## Problem Statement
+
+Current `wifi_connect_tls` requires passing full PEM content for each connection:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Current Flow (Slow)                                            │
+│                                                                 │
+│  AI Agent ──────────────────────────────────────────────────────│
+│      │                                                          │
+│      │  1. Read cert files locally                              │
+│      │  2. Generate large JSON with PEM content (~1.5 min)      │
+│      │  3. Call wifi_connect_tls with full PEM                  │
+│      │                                                          │
+│      ▼                                                          │
+│  MCP Server                                                     │
+│      │                                                          │
+│      │  4. Write temp files                                     │
+│      │  5. Connect                                              │
+│      │  6. Cleanup temp files                                   │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Problems:**
+- AI takes ~1.5 min to format/generate large PEM parameters
+- Repeated for every connection attempt
+- PEM content visible in conversation history
+- No way to list/manage stored credentials remotely
+
+---
+
+## Solution: Credential Store
+
+Store credentials on the MCP server with a simple ID reference:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  New Flow (Fast)                                                │
+│                                                                 │
+│  AI Agent ──────────────────────────────────────────────────────│
+│      │                                                          │
+│      │  One-time setup:                                         │
+│      │    credential_store (upload cert, key, ca)               │
+│      │    Returns: credential_id = "corp-wifi-2026"             │
+│      │                                                          │
+│      │  Each connection (fast):                                 │
+│      │    wifi_connect_tls(ssid, credential_id="corp-wifi-2026")│
+│      │                                                          │
+│      ▼                                                          │
+│  MCP Server                                                     │
+│      │                                                          │
+│      │  1. Load certs from store by ID                          │
+│      │  2. Connect using stored certs                           │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## User Flow
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                     Credential Lifecycle                        │
+└─────────────────────────────────────────────────────────────────┘
+
+     CREATE                  READ                    DELETE
+        │                      │                        │
+        ▼                      ▼                        ▼
+┌───────────────┐      ┌───────────────┐       ┌───────────────┐
+│credential_store│      │credential_get │       │credential_    │
+│               │      │               │       │  delete       │
+│ id: "my-cert" │      │ id: "my-cert" │       │               │
+│ client_cert   │      │               │       │ id: "my-cert" │
+│ private_key   │      │ Returns:      │       │               │
+│ ca_cert       │      │  - identity   │       │ Removes all   │
+│ identity      │      │  - created_at │       │ cert files    │
+└───────┬───────┘      │  - has_ca     │       └───────────────┘
+        │              │  - cert info  │
+        ▼              └───────────────┘
+┌───────────────┐
+│ Stored at:    │              LIST
+│ ~/.config/    │                │
+│  wpa-mcp/     │                ▼
+│  credentials/ │      ┌───────────────┐
+│  my-cert/     │      │credential_list│
+│   client.crt  │      │               │
+│   client.key  │      │ Returns:      │
+│   ca.crt      │      │  [{id, ...}]  │
+│   meta.json   │      └───────────────┘
+└───────────────┘
+```
+
+---
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                         MCP Client                              │
+│                  (Claude Desktop / Claude Code)                 │
+└────────────────────────────┬────────────────────────────────────┘
+                             │
+                             │  credential_store / credential_get / etc.
+                             ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                   src/tools/credentials.ts                      │
+│                                                                 │
+│  Tools:                                                         │
+│  ├── credential_store    (create/update)                        │
+│  ├── credential_get      (read metadata + optionally PEM)       │
+│  ├── credential_list     (list all stored)                      │
+│  └── credential_delete   (remove)                               │
+└────────────────────────────┬────────────────────────────────────┘
+                             │
+                             ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                src/lib/credential-store.ts                      │
+│                                                                 │
+│  CredentialStore class:                                         │
+│  ├── store(id, certs, metadata)                                 │
+│  ├── get(id) → { paths, metadata }                              │
+│  ├── list() → [{ id, metadata }]                                │
+│  ├── delete(id)                                                 │
+│  └── exists(id) → boolean                                       │
+└────────────────────────────┬────────────────────────────────────┘
+                             │
+                             ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                    File System Storage                          │
+│                                                                 │
+│  ~/.config/wpa-mcp/credentials/                                 │
+│  ├── corp-wifi/                                                 │
+│  │   ├── client.crt                                             │
+│  │   ├── client.key      (mode 0600)                            │
+│  │   ├── ca.crt                                                 │
+│  │   └── meta.json       { identity, created_at, ... }          │
+│  └── guest-network/                                             │
+│      └── ...                                                    │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## API: Credential Tools
+
+### credential_store
+
+Create or update a stored credential.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| id | string | Yes | Unique identifier (alphanumeric, dash, underscore) |
+| identity | string | Yes | Identity for EAP (CN from cert) |
+| client_cert_pem | string | Yes | PEM-encoded client certificate |
+| private_key_pem | string | Yes | PEM-encoded private key |
+| ca_cert_pem | string | No | PEM-encoded CA certificate |
+| private_key_password | string | No | Stored encrypted passphrase |
+| description | string | No | Human-readable description |
+
+**Returns:**
+```json
+{
+  "success": true,
+  "id": "corp-wifi",
+  "created": true,
+  "path": "/home/user/.config/wpa-mcp/credentials/corp-wifi"
+}
+```
+
+### credential_get
+
+Read credential metadata and optionally certificate content.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| id | string | Yes | Credential identifier |
+| include_certs | boolean | No | Include PEM content (default: false) |
+
+**Returns:**
+```json
+{
+  "success": true,
+  "id": "corp-wifi",
+  "identity": "device.example.com",
+  "description": "Corporate WiFi cert",
+  "created_at": "2026-01-13T10:00:00Z",
+  "has_ca_cert": true,
+  "has_key_password": false,
+  "cert_info": {
+    "subject": "CN=device.example.com",
+    "issuer": "CN=Corporate CA",
+    "not_after": "2027-01-13T00:00:00Z"
+  }
+}
+```
+
+### credential_list
+
+List all stored credentials.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+
+**Returns:**
+```json
+{
+  "success": true,
+  "credentials": [
+    {
+      "id": "corp-wifi",
+      "identity": "device.example.com",
+      "description": "Corporate WiFi",
+      "created_at": "2026-01-13T10:00:00Z"
+    }
+  ],
+  "count": 1
+}
+```
+
+### credential_delete
+
+Remove a stored credential.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| id | string | Yes | Credential identifier |
+
+**Returns:**
+```json
+{
+  "success": true,
+  "id": "corp-wifi",
+  "deleted": true
+}
+```
+
+---
+
+## Updated wifi_connect_tls
+
+Add optional `credential_id` parameter:
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| ssid | string | Yes | Network SSID |
+| credential_id | string | No* | Reference to stored credential |
+| identity | string | No* | Identity (required if no credential_id) |
+| client_cert_pem | string | No* | PEM cert (required if no credential_id) |
+| private_key_pem | string | No* | PEM key (required if no credential_id) |
+| ca_cert_pem | string | No | PEM CA cert |
+| ... | | | (other params unchanged) |
+
+*Either `credential_id` OR (`identity` + `client_cert_pem` + `private_key_pem`) required.
+
+**Example with credential_id:**
+```json
+{
+  "ssid": "CorpWiFi",
+  "credential_id": "corp-wifi"
+}
+```
+
+---
+
+## Implementation
+
+### Files to Create
+
+| File | Description |
+|------|-------------|
+| `src/lib/credential-store.ts` | CredentialStore class with CRUD operations |
+| `src/tools/credentials.ts` | MCP tool definitions |
+
+### Files to Modify
+
+| File | Changes |
+|------|---------|
+| `src/index.ts` | Register credential tools |
+| `src/tools/wifi.ts` | Add credential_id support to wifi_connect_tls |
+
+---
+
+## Storage Format
+
+### Directory Structure
+
+```
+~/.config/wpa-mcp/credentials/
+└── {credential_id}/
+    ├── client.crt     # PEM certificate (mode 0600)
+    ├── client.key     # PEM private key (mode 0600)
+    ├── ca.crt         # PEM CA cert (optional, mode 0600)
+    └── meta.json      # Metadata
+```
+
+### meta.json
+
+```json
+{
+  "id": "corp-wifi",
+  "identity": "device.example.com",
+  "description": "Corporate WiFi certificate",
+  "created_at": "2026-01-13T10:00:00Z",
+  "updated_at": "2026-01-13T10:00:00Z",
+  "has_ca_cert": true,
+  "has_key_password": false
+}
+```
+
+---
+
+## Security Considerations
+
+| Concern | Mitigation |
+|---------|------------|
+| Private key exposure | File mode 0600, directory mode 0700 |
+| Credential enumeration | ID validation, no wildcards |
+| Key password storage | Stored in meta.json (encrypted at rest by OS) |
+| Unauthorized access | Follows OS user permissions |
+
+---
+
+## Error Handling
+
+| Error | Message | Resolution |
+|-------|---------|------------|
+| ID not found | `Credential 'xxx' not found` | Use credential_list to see available |
+| Invalid ID | `Invalid credential ID: must be alphanumeric, dash, underscore` | Fix ID format |
+| Invalid PEM | `Invalid PEM format for client_cert` | Check certificate format |
+| Permission denied | `Cannot write to credential store` | Check directory permissions |
+
+---
+
+## Usage Examples
+
+### Store a New Credential
+
+```
+User: Store my corporate WiFi certificate
+
+AI: I'll store the credential. First, let me read the certificate files.
+    [reads local cert files]
+    
+    Now storing with credential_store:
+    {
+      "id": "corp-wifi",
+      "identity": "device.example.com", 
+      "client_cert_pem": "-----BEGIN CERTIFICATE-----...",
+      "private_key_pem": "-----BEGIN PRIVATE KEY-----...",
+      "ca_cert_pem": "-----BEGIN CERTIFICATE-----...",
+      "description": "Corporate WiFi - expires 2027"
+    }
+    
+    Credential stored successfully as 'corp-wifi'.
+```
+
+### Connect Using Stored Credential
+
+```
+User: Connect to CorpWiFi
+
+AI: Connecting using stored credential:
+    {
+      "ssid": "CorpWiFi",
+      "credential_id": "corp-wifi"
+    }
+    
+    Connected successfully!
+```
+
+### List and Manage Credentials
+
+```
+User: What credentials do I have stored?
+
+AI: [calls credential_list]
+    
+    You have 2 stored credentials:
+    1. corp-wifi - device.example.com (expires 2027-01-13)
+    2. guest-cert - guest.example.com (expires 2026-06-01)
+```
+
+---
+
+## Testing
+
+### Unit Tests
+
+```bash
+# Test credential store operations
+npm test -- --grep "CredentialStore"
+```
+
+### Manual Testing
+
+```bash
+# Store credential
+curl -X POST http://localhost:3000/mcp -d '{
+  "method": "tools/call",
+  "params": {
+    "name": "credential_store",
+    "arguments": {
+      "id": "test-cert",
+      "identity": "test@example.com",
+      "client_cert_pem": "...",
+      "private_key_pem": "..."
+    }
+  }
+}'
+
+# List credentials
+curl -X POST http://localhost:3000/mcp -d '{
+  "method": "tools/call",
+  "params": {
+    "name": "credential_list",
+    "arguments": {}
+  }
+}'
+```
+
+---
+
+## References
+
+- [802.1x-credential-auth.md](./802.1x-credential-auth.md) - Original EAP-TLS design
+- [XDG Base Directory Spec](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) - Config directory location

--- a/scripts/gen-tls-call.sh
+++ b/scripts/gen-tls-call.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Generate wifi_connect_tls tool call JSON from certificate files
+# Usage: ./scripts/gen-tls-call.sh <ssid> <identity> <client.crt> <client.key> <ca.crt> [output.json]
+
+set -e
+
+SSID="$1"
+IDENTITY="$2"
+CLIENT_CERT="$3"
+PRIVATE_KEY="$4"
+CA_CERT="$5"
+OUTPUT="${6:-/tmp/tls-call.json}"
+
+if [[ -z "$SSID" || -z "$IDENTITY" || -z "$CLIENT_CERT" || -z "$PRIVATE_KEY" || -z "$CA_CERT" ]]; then
+  echo "Usage: $0 <ssid> <identity> <client.crt> <client.key> <ca.crt> [output.json]"
+  echo ""
+  echo "Example:"
+  echo "  $0 'SecureWiFi' 'device.example.com' client.crt client.key ca.crt"
+  exit 1
+fi
+
+# Check files exist
+for f in "$CLIENT_CERT" "$PRIVATE_KEY" "$CA_CERT"; do
+  if [[ ! -f "$f" ]]; then
+    echo "Error: File not found: $f"
+    exit 1
+  fi
+done
+
+# Check jq is installed
+if ! command -v jq &> /dev/null; then
+  echo "Error: jq is required. Install with: apt install jq"
+  exit 1
+fi
+
+# Read and escape PEM content for JSON
+read_pem() {
+  jq -Rs . < "$1"
+}
+
+cat > "$OUTPUT" << EOF
+{
+  "ssid": "$SSID",
+  "identity": "$IDENTITY",
+  "client_cert_pem": $(read_pem "$CLIENT_CERT"),
+  "private_key_pem": $(read_pem "$PRIVATE_KEY"),
+  "ca_cert_pem": $(read_pem "$CA_CERT")
+}
+EOF
+
+echo "Generated: $OUTPUT"
+echo ""
+echo "Tell AI: Call wifi_connect_tls with params from $OUTPUT"

--- a/src/lib/cert-manager.ts
+++ b/src/lib/cert-manager.ts
@@ -1,0 +1,38 @@
+import { writeFile, unlink, mkdir } from 'fs/promises';
+import { join } from 'path';
+import { randomBytes } from 'crypto';
+
+const TEMP_DIR = '/tmp/wpa-mcp-certs';
+
+export interface CertFiles {
+  clientCert: string;
+  privateKey: string;
+  caCert: string;
+  cleanup: () => Promise<void>;
+}
+
+export async function writeTempCerts(
+  clientCertPem: string,
+  privateKeyPem: string,
+  caCertPem: string
+): Promise<CertFiles> {
+  const id = randomBytes(8).toString('hex');
+
+  await mkdir(TEMP_DIR, { recursive: true, mode: 0o700 });
+
+  const clientCert = join(TEMP_DIR, `client-${id}.crt`);
+  const privateKey = join(TEMP_DIR, `client-${id}.key`);
+  const caCert = join(TEMP_DIR, `ca-${id}.crt`);
+
+  await writeFile(clientCert, clientCertPem, { mode: 0o600 });
+  await writeFile(privateKey, privateKeyPem, { mode: 0o600 });
+  await writeFile(caCert, caCertPem, { mode: 0o600 });
+
+  const cleanup = async () => {
+    await unlink(clientCert).catch(() => {});
+    await unlink(privateKey).catch(() => {});
+    await unlink(caCert).catch(() => {});
+  };
+
+  return { clientCert, privateKey, caCert, cleanup };
+}

--- a/src/lib/wpa-cli.ts
+++ b/src/lib/wpa-cli.ts
@@ -1,12 +1,17 @@
-import { exec } from 'child_process';
-import { promisify } from 'util';
-import type { Network, SavedNetwork, ConnectionStatus, MacAddressConfig } from '../types.js';
-import { macModeToWpaValue, preassocModeToWpaValue } from './mac-utils.js';
+import { exec } from "child_process";
+import { promisify } from "util";
+import type {
+  Network,
+  SavedNetwork,
+  ConnectionStatus,
+  MacAddressConfig,
+} from "../types.js";
+import { macModeToWpaValue, preassocModeToWpaValue } from "./mac-utils.js";
 
 const execAsync = promisify(exec);
 
 export class WpaCli {
-  constructor(private iface: string = 'wlan0') {}
+  constructor(private iface: string = "wlan0") {}
 
   private async run(command: string): Promise<string> {
     const { stdout } = await execAsync(`wpa_cli -i ${this.iface} ${command}`);
@@ -15,8 +20,8 @@ export class WpaCli {
 
   async scan(): Promise<Network[]> {
     // Initiate scan
-    const scanResult = await this.run('scan');
-    if (!scanResult.includes('OK')) {
+    const scanResult = await this.run("scan");
+    if (!scanResult.includes("OK")) {
       throw new Error(`Scan failed: ${scanResult}`);
     }
 
@@ -24,26 +29,30 @@ export class WpaCli {
     await new Promise((resolve) => setTimeout(resolve, 3000));
 
     // Get results
-    const output = await this.run('scan_results');
-    const lines = output.split('\n').slice(1); // Skip header
+    const output = await this.run("scan_results");
+    const lines = output.split("\n").slice(1); // Skip header
 
     return lines
       .filter((line) => line.trim())
       .map((line) => {
-        const parts = line.split('\t');
+        const parts = line.split("\t");
         return {
-          bssid: parts[0] || '',
-          frequency: parseInt(parts[1] || '0', 10),
-          signal: parseInt(parts[2] || '0', 10),
-          flags: parts[3] || '',
-          ssid: parts[4] || '',
+          bssid: parts[0] || "",
+          frequency: parseInt(parts[1] || "0", 10),
+          signal: parseInt(parts[2] || "0", 10),
+          flags: parts[3] || "",
+          ssid: parts[4] || "",
         };
       });
   }
 
-  async connect(ssid: string, psk?: string, macConfig?: MacAddressConfig): Promise<void> {
+  async connect(
+    ssid: string,
+    psk?: string,
+    macConfig?: MacAddressConfig,
+  ): Promise<void> {
     // Add new network
-    const networkIdStr = await this.run('add_network');
+    const networkIdStr = await this.run("add_network");
     const networkId = parseInt(networkIdStr, 10);
 
     if (isNaN(networkId)) {
@@ -53,26 +62,26 @@ export class WpaCli {
     try {
       // Set SSID
       const ssidResult = await this.run(
-        `set_network ${networkId} ssid '"${ssid}"'`
+        `set_network ${networkId} ssid '"${ssid}"'`,
       );
-      if (!ssidResult.includes('OK')) {
+      if (!ssidResult.includes("OK")) {
         throw new Error(`Failed to set SSID: ${ssidResult}`);
       }
 
       if (psk) {
         // WPA/WPA2 network with password
         const pskResult = await this.run(
-          `set_network ${networkId} psk '"${psk}"'`
+          `set_network ${networkId} psk '"${psk}"'`,
         );
-        if (!pskResult.includes('OK')) {
+        if (!pskResult.includes("OK")) {
           throw new Error(`Failed to set PSK: ${pskResult}`);
         }
       } else {
         // Open network
         const keyMgmtResult = await this.run(
-          `set_network ${networkId} key_mgmt NONE`
+          `set_network ${networkId} key_mgmt NONE`,
         );
-        if (!keyMgmtResult.includes('OK')) {
+        if (!keyMgmtResult.includes("OK")) {
           throw new Error(`Failed to set key_mgmt: ${keyMgmtResult}`);
         }
       }
@@ -84,18 +93,18 @@ export class WpaCli {
 
       // Enable network
       const enableResult = await this.run(`enable_network ${networkId}`);
-      if (!enableResult.includes('OK')) {
+      if (!enableResult.includes("OK")) {
         throw new Error(`Failed to enable network: ${enableResult}`);
       }
 
       // Select this network
       const selectResult = await this.run(`select_network ${networkId}`);
-      if (!selectResult.includes('OK')) {
+      if (!selectResult.includes("OK")) {
         throw new Error(`Failed to select network: ${selectResult}`);
       }
 
       // Save config
-      await this.run('save_config');
+      await this.run("save_config");
     } catch (error) {
       // Clean up on failure
       await this.run(`remove_network ${networkId}`).catch(() => {});
@@ -107,12 +116,12 @@ export class WpaCli {
     ssid: string,
     identity: string,
     password: string,
-    eapMethod: string = 'PEAP',
-    phase2: string = 'MSCHAPV2',
-    macConfig?: MacAddressConfig
+    eapMethod: string = "PEAP",
+    phase2: string = "MSCHAPV2",
+    macConfig?: MacAddressConfig,
   ): Promise<void> {
     // Add new network
-    const networkIdStr = await this.run('add_network');
+    const networkIdStr = await this.run("add_network");
     const networkId = parseInt(networkIdStr, 10);
 
     if (isNaN(networkId)) {
@@ -122,50 +131,50 @@ export class WpaCli {
     try {
       // Set SSID
       const ssidResult = await this.run(
-        `set_network ${networkId} ssid '"${ssid}"'`
+        `set_network ${networkId} ssid '"${ssid}"'`,
       );
-      if (!ssidResult.includes('OK')) {
+      if (!ssidResult.includes("OK")) {
         throw new Error(`Failed to set SSID: ${ssidResult}`);
       }
 
       // Set key management to WPA-EAP
       const keyMgmtResult = await this.run(
-        `set_network ${networkId} key_mgmt WPA-EAP`
+        `set_network ${networkId} key_mgmt WPA-EAP`,
       );
-      if (!keyMgmtResult.includes('OK')) {
+      if (!keyMgmtResult.includes("OK")) {
         throw new Error(`Failed to set key_mgmt: ${keyMgmtResult}`);
       }
 
       // Set EAP method
       const eapResult = await this.run(
-        `set_network ${networkId} eap ${eapMethod}`
+        `set_network ${networkId} eap ${eapMethod}`,
       );
-      if (!eapResult.includes('OK')) {
+      if (!eapResult.includes("OK")) {
         throw new Error(`Failed to set EAP method: ${eapResult}`);
       }
 
       // Set identity (username)
       const identityResult = await this.run(
-        `set_network ${networkId} identity '"${identity}"'`
+        `set_network ${networkId} identity '"${identity}"'`,
       );
-      if (!identityResult.includes('OK')) {
+      if (!identityResult.includes("OK")) {
         throw new Error(`Failed to set identity: ${identityResult}`);
       }
 
       // Set password
       const passwordResult = await this.run(
-        `set_network ${networkId} password '"${password}"'`
+        `set_network ${networkId} password '"${password}"'`,
       );
-      if (!passwordResult.includes('OK')) {
+      if (!passwordResult.includes("OK")) {
         throw new Error(`Failed to set password: ${passwordResult}`);
       }
 
       // Set phase2 authentication (for PEAP/TTLS)
-      if (eapMethod === 'PEAP' || eapMethod === 'TTLS') {
+      if (eapMethod === "PEAP" || eapMethod === "TTLS") {
         const phase2Result = await this.run(
-          `set_network ${networkId} phase2 '"auth=${phase2}"'`
+          `set_network ${networkId} phase2 '"auth=${phase2}"'`,
         );
-        if (!phase2Result.includes('OK')) {
+        if (!phase2Result.includes("OK")) {
           throw new Error(`Failed to set phase2: ${phase2Result}`);
         }
       }
@@ -177,18 +186,18 @@ export class WpaCli {
 
       // Enable network
       const enableResult = await this.run(`enable_network ${networkId}`);
-      if (!enableResult.includes('OK')) {
+      if (!enableResult.includes("OK")) {
         throw new Error(`Failed to enable network: ${enableResult}`);
       }
 
       // Select this network
       const selectResult = await this.run(`select_network ${networkId}`);
-      if (!selectResult.includes('OK')) {
+      if (!selectResult.includes("OK")) {
         throw new Error(`Failed to select network: ${selectResult}`);
       }
 
       // Save config
-      await this.run('save_config');
+      await this.run("save_config");
     } catch (error) {
       // Clean up on failure
       await this.run(`remove_network ${networkId}`).catch(() => {});
@@ -196,13 +205,16 @@ export class WpaCli {
     }
   }
 
-  private async applyMacConfig(networkId: number, config: MacAddressConfig): Promise<void> {
+  private async applyMacConfig(
+    networkId: number,
+    config: MacAddressConfig,
+  ): Promise<void> {
     // Set mac_addr parameter
     const macValue = macModeToWpaValue(config.mode, config.address);
     const macResult = await this.run(
-      `set_network ${networkId} mac_addr ${macValue}`
+      `set_network ${networkId} mac_addr ${macValue}`,
     );
-    if (!macResult.includes('OK')) {
+    if (!macResult.includes("OK")) {
       throw new Error(`Failed to set mac_addr: ${macResult}`);
     }
 
@@ -210,9 +222,9 @@ export class WpaCli {
     if (config.preassocMode) {
       const preassocValue = preassocModeToWpaValue(config.preassocMode);
       const preassocResult = await this.run(
-        `set_network ${networkId} preassoc_mac_addr ${preassocValue}`
+        `set_network ${networkId} preassoc_mac_addr ${preassocValue}`,
       );
-      if (!preassocResult.includes('OK')) {
+      if (!preassocResult.includes("OK")) {
         throw new Error(`Failed to set preassoc_mac_addr: ${preassocResult}`);
       }
     }
@@ -220,62 +232,62 @@ export class WpaCli {
     // Set rand_addr_lifetime if specified (only relevant for random modes)
     if (
       config.randAddrLifetime !== undefined &&
-      (config.mode === 'random' || config.mode === 'persistent-random')
+      (config.mode === "random" || config.mode === "persistent-random")
     ) {
       const lifetimeResult = await this.run(
-        `set_network ${networkId} rand_addr_lifetime ${config.randAddrLifetime}`
+        `set_network ${networkId} rand_addr_lifetime ${config.randAddrLifetime}`,
       );
-      if (!lifetimeResult.includes('OK')) {
+      if (!lifetimeResult.includes("OK")) {
         throw new Error(`Failed to set rand_addr_lifetime: ${lifetimeResult}`);
       }
     }
   }
 
   async disconnect(): Promise<void> {
-    const result = await this.run('disconnect');
-    if (!result.includes('OK')) {
+    const result = await this.run("disconnect");
+    if (!result.includes("OK")) {
       throw new Error(`Disconnect failed: ${result}`);
     }
   }
 
   async reconnect(): Promise<void> {
-    const result = await this.run('reconnect');
-    if (!result.includes('OK')) {
+    const result = await this.run("reconnect");
+    if (!result.includes("OK")) {
       throw new Error(`Reconnect failed: ${result}`);
     }
   }
 
   async status(): Promise<ConnectionStatus> {
-    const output = await this.run('status');
-    const lines = output.split('\n');
+    const output = await this.run("status");
+    const lines = output.split("\n");
     const status: ConnectionStatus = {
-      wpaState: 'UNKNOWN',
+      wpaState: "UNKNOWN",
     };
 
     for (const line of lines) {
-      const [key, value] = line.split('=');
+      const [key, value] = line.split("=");
       if (!key || !value) continue;
 
       switch (key) {
-        case 'wpa_state':
+        case "wpa_state":
           status.wpaState = value;
           break;
-        case 'ssid':
+        case "ssid":
           status.ssid = value;
           break;
-        case 'bssid':
+        case "bssid":
           status.bssid = value;
           break;
-        case 'ip_address':
+        case "ip_address":
           status.ipAddress = value;
           break;
-        case 'freq':
+        case "freq":
           status.frequency = parseInt(value, 10);
           break;
-        case 'key_mgmt':
+        case "key_mgmt":
           status.keyManagement = value;
           break;
-        case 'address':
+        case "address":
           status.address = value;
           break;
       }
@@ -287,7 +299,7 @@ export class WpaCli {
   async waitForState(
     targetState: string,
     timeoutMs: number = 15000,
-    pollIntervalMs: number = 500
+    pollIntervalMs: number = 500,
   ): Promise<{ reached: boolean; status: ConnectionStatus }> {
     const maxAttempts = Math.ceil(timeoutMs / pollIntervalMs);
 
@@ -300,32 +312,35 @@ export class WpaCli {
     }
 
     const finalStatus = await this.status();
-    return { reached: finalStatus.wpaState === targetState, status: finalStatus };
+    return {
+      reached: finalStatus.wpaState === targetState,
+      status: finalStatus,
+    };
   }
 
   async listNetworks(): Promise<SavedNetwork[]> {
-    const output = await this.run('list_networks');
-    const lines = output.split('\n').slice(1); // Skip header
+    const output = await this.run("list_networks");
+    const lines = output.split("\n").slice(1); // Skip header
 
     return lines
       .filter((line) => line.trim())
       .map((line) => {
-        const parts = line.split('\t');
+        const parts = line.split("\t");
         return {
-          networkId: parseInt(parts[0] || '0', 10),
-          ssid: parts[1] || '',
-          bssid: parts[2] || 'any',
-          flags: parts[3] || '',
+          networkId: parseInt(parts[0] || "0", 10),
+          ssid: parts[1] || "",
+          bssid: parts[2] || "any",
+          flags: parts[3] || "",
         };
       });
   }
 
   async removeNetwork(networkId: number): Promise<void> {
     const result = await this.run(`remove_network ${networkId}`);
-    if (!result.includes('OK')) {
+    if (!result.includes("OK")) {
       throw new Error(`Failed to remove network: ${result}`);
     }
-    await this.run('save_config');
+    await this.run("save_config");
   }
 
   async getInterface(): Promise<string> {
@@ -333,11 +348,11 @@ export class WpaCli {
   }
 
   async statusVerbose(): Promise<Record<string, string>> {
-    const output = await this.run('status verbose');
+    const output = await this.run("status verbose");
     const result: Record<string, string> = {};
 
-    for (const line of output.split('\n')) {
-      const idx = line.indexOf('=');
+    for (const line of output.split("\n")) {
+      const idx = line.indexOf("=");
       if (idx > 0) {
         const key = line.substring(0, idx);
         const value = line.substring(idx + 1);
@@ -349,11 +364,11 @@ export class WpaCli {
   }
 
   async getMib(): Promise<Record<string, string>> {
-    const output = await this.run('mib');
+    const output = await this.run("mib");
     const result: Record<string, string> = {};
 
-    for (const line of output.split('\n')) {
-      const idx = line.indexOf('=');
+    for (const line of output.split("\n")) {
+      const idx = line.indexOf("=");
       if (idx > 0) {
         const key = line.substring(0, idx);
         const value = line.substring(idx + 1);
@@ -362,6 +377,116 @@ export class WpaCli {
     }
 
     return result;
+  }
+
+  async connectTls(
+    ssid: string,
+    identity: string,
+    clientCertPath: string,
+    privateKeyPath: string,
+    caCertPath: string,
+    privateKeyPassword?: string,
+    macConfig?: MacAddressConfig,
+  ): Promise<void> {
+    const networkIdStr = await this.run("add_network");
+    const networkId = parseInt(networkIdStr, 10);
+
+    if (isNaN(networkId)) {
+      throw new Error(`Failed to add network: ${networkIdStr}`);
+    }
+
+    try {
+      // Set SSID
+      const ssidResult = await this.run(
+        `set_network ${networkId} ssid '"${ssid}"'`,
+      );
+      if (!ssidResult.includes("OK")) {
+        throw new Error(`Failed to set SSID: ${ssidResult}`);
+      }
+
+      // Set key management to WPA-EAP
+      const keyMgmtResult = await this.run(
+        `set_network ${networkId} key_mgmt WPA-EAP`,
+      );
+      if (!keyMgmtResult.includes("OK")) {
+        throw new Error(`Failed to set key_mgmt: ${keyMgmtResult}`);
+      }
+
+      // Set EAP method to TLS
+      const eapResult = await this.run(`set_network ${networkId} eap TLS`);
+      if (!eapResult.includes("OK")) {
+        throw new Error(`Failed to set EAP method: ${eapResult}`);
+      }
+
+      // Set identity
+      const identityResult = await this.run(
+        `set_network ${networkId} identity '"${identity}"'`,
+      );
+      if (!identityResult.includes("OK")) {
+        throw new Error(`Failed to set identity: ${identityResult}`);
+      }
+
+      // Set client certificate
+      const clientCertResult = await this.run(
+        `set_network ${networkId} client_cert '"${clientCertPath}"'`,
+      );
+      if (!clientCertResult.includes("OK")) {
+        throw new Error(`Failed to set client_cert: ${clientCertResult}`);
+      }
+
+      // Set private key
+      const privateKeyResult = await this.run(
+        `set_network ${networkId} private_key '"${privateKeyPath}"'`,
+      );
+      if (!privateKeyResult.includes("OK")) {
+        throw new Error(`Failed to set private_key: ${privateKeyResult}`);
+      }
+
+      // Set CA certificate
+      const caCertResult = await this.run(
+        `set_network ${networkId} ca_cert '"${caCertPath}"'`,
+      );
+      if (!caCertResult.includes("OK")) {
+        throw new Error(`Failed to set ca_cert: ${caCertResult}`);
+      }
+
+      // Set private key password if provided
+      if (privateKeyPassword) {
+        const passwordResult = await this.run(
+          `set_network ${networkId} private_key_passwd '"${privateKeyPassword}"'`,
+        );
+        if (!passwordResult.includes("OK")) {
+          throw new Error(
+            `Failed to set private_key_passwd: ${passwordResult}`,
+          );
+        }
+      }
+
+      // Apply MAC address configuration if provided
+      if (macConfig) {
+        await this.applyMacConfig(networkId, macConfig);
+      }
+
+      // Enable network
+      const enableResult = await this.run(`enable_network ${networkId}`);
+      if (!enableResult.includes("OK")) {
+        throw new Error(`Failed to enable network: ${enableResult}`);
+      }
+
+      // Select this network
+      const selectResult = await this.run(`select_network ${networkId}`);
+      if (!selectResult.includes("OK")) {
+        throw new Error(`Failed to select network: ${selectResult}`);
+      }
+
+      // Save config
+      await this.run("save_config");
+    } catch (error) {
+      // Clean up on failure
+      await this.run(`remove_network ${networkId}`).catch(() => {});
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`EAP-TLS connection to ${ssid} failed: ${message}`);
+    }
   }
 
   async getEapDiagnostics(): Promise<{
@@ -381,15 +506,21 @@ export class WpaCli {
     ]);
 
     return {
-      eapState: status['EAP state'] || 'UNKNOWN',
-      decision: status['decision'] || 'UNKNOWN',
-      paeState: status['Supplicant PAE state'] || 'UNKNOWN',
-      portStatus: status['suppPortStatus'] || mib['dot1xSuppSuppControlledPortStatus'] || 'UNKNOWN',
-      methodState: status['methodState'] || 'UNKNOWN',
-      eapolFramesRx: parseInt(mib['dot1xSuppEapolFramesRx'] || '0', 10),
-      eapolFramesTx: parseInt(mib['dot1xSuppEapolFramesTx'] || '0', 10),
-      reqIdFramesRx: parseInt(mib['dot1xSuppEapolReqIdFramesRx'] || '0', 10),
-      handshakeFailures: parseInt(mib['dot11RSNA4WayHandshakeFailures'] || '0', 10),
+      eapState: status["EAP state"] || "UNKNOWN",
+      decision: status["decision"] || "UNKNOWN",
+      paeState: status["Supplicant PAE state"] || "UNKNOWN",
+      portStatus:
+        status["suppPortStatus"] ||
+        mib["dot1xSuppSuppControlledPortStatus"] ||
+        "UNKNOWN",
+      methodState: status["methodState"] || "UNKNOWN",
+      eapolFramesRx: parseInt(mib["dot1xSuppEapolFramesRx"] || "0", 10),
+      eapolFramesTx: parseInt(mib["dot1xSuppEapolFramesTx"] || "0", 10),
+      reqIdFramesRx: parseInt(mib["dot1xSuppEapolReqIdFramesRx"] || "0", 10),
+      handshakeFailures: parseInt(
+        mib["dot11RSNA4WayHandshakeFailures"] || "0",
+        10,
+      ),
     };
   }
 }

--- a/src/lib/wpa-cli.ts
+++ b/src/lib/wpa-cli.ts
@@ -384,7 +384,7 @@ export class WpaCli {
     identity: string,
     clientCertPath: string,
     privateKeyPath: string,
-    caCertPath: string,
+    caCertPath?: string,
     privateKeyPassword?: string,
     macConfig?: MacAddressConfig,
   ): Promise<void> {
@@ -442,12 +442,14 @@ export class WpaCli {
         throw new Error(`Failed to set private_key: ${privateKeyResult}`);
       }
 
-      // Set CA certificate
-      const caCertResult = await this.run(
-        `set_network ${networkId} ca_cert '"${caCertPath}"'`,
-      );
-      if (!caCertResult.includes("OK")) {
-        throw new Error(`Failed to set ca_cert: ${caCertResult}`);
+      // Set CA certificate (optional - if not provided, server cert is not validated)
+      if (caCertPath) {
+        const caCertResult = await this.run(
+          `set_network ${networkId} ca_cert '"${caCertPath}"'`,
+        );
+        if (!caCertResult.includes("OK")) {
+          throw new Error(`Failed to set ca_cert: ${caCertResult}`);
+        }
       }
 
       // Set private key password if provided

--- a/src/tools/credentials.ts
+++ b/src/tools/credentials.ts
@@ -1,0 +1,285 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { credentialStore } from "../lib/credential-store.js";
+
+export function registerCredentialTools(server: McpServer): void {
+  // credential_store - Create or update a stored credential
+  server.tool(
+    "credential_store",
+    "Store EAP-TLS certificates for later use with wifi_connect_tls. " +
+      "Certificates are stored securely on the MCP server. " +
+      "Use credential_id parameter in wifi_connect_tls to connect without passing full PEM content.",
+    {
+      id: z
+        .string()
+        .describe(
+          "Unique identifier for this credential (alphanumeric, dash, underscore, max 64 chars)"
+        ),
+      identity: z
+        .string()
+        .describe("Identity for EAP authentication (typically CN from client certificate)"),
+      client_cert_pem: z.string().describe("PEM-encoded client certificate"),
+      private_key_pem: z.string().describe("PEM-encoded private key"),
+      ca_cert_pem: z
+        .string()
+        .optional()
+        .describe("PEM-encoded CA certificate for server validation"),
+      private_key_password: z
+        .string()
+        .optional()
+        .describe("Passphrase for encrypted private key"),
+      description: z
+        .string()
+        .optional()
+        .describe("Human-readable description of this credential"),
+    },
+    async ({
+      id,
+      identity,
+      client_cert_pem,
+      private_key_pem,
+      ca_cert_pem,
+      private_key_password,
+      description,
+    }) => {
+      try {
+        const result = await credentialStore.store(
+          id,
+          identity,
+          client_cert_pem,
+          private_key_pem,
+          ca_cert_pem,
+          private_key_password,
+          description
+        );
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(
+                {
+                  success: true,
+                  id,
+                  created: result.created,
+                  updated: !result.created,
+                  path: result.path,
+                  message: result.created
+                    ? `Credential '${id}' created successfully`
+                    : `Credential '${id}' updated successfully`,
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                success: false,
+                error: error instanceof Error ? error.message : String(error),
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // credential_get - Get credential metadata and optionally PEM content
+  server.tool(
+    "credential_get",
+    "Get details of a stored credential. Returns metadata (identity, dates, cert info). " +
+      "Use include_certs=true to also return PEM content.",
+    {
+      id: z.string().describe("Credential identifier"),
+      include_certs: z
+        .boolean()
+        .optional()
+        .describe("Include PEM certificate content in response (default: false)"),
+    },
+    async ({ id, include_certs }) => {
+      try {
+        const credential = await credentialStore.get(id);
+
+        if (!credential) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify({
+                  success: false,
+                  error: `Credential '${id}' not found`,
+                }),
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        const certInfo = await credentialStore.getCertInfo(id);
+
+        const response: Record<string, unknown> = {
+          success: true,
+          id: credential.metadata.id,
+          identity: credential.metadata.identity,
+          description: credential.metadata.description,
+          created_at: credential.metadata.created_at,
+          updated_at: credential.metadata.updated_at,
+          has_ca_cert: credential.metadata.has_ca_cert,
+          has_key_password: credential.metadata.has_key_password,
+          cert_info: certInfo,
+        };
+
+        if (include_certs) {
+          const pemContent = await credentialStore.getPemContent(id);
+          if (pemContent) {
+            response.client_cert_pem = pemContent.client_cert_pem;
+            response.private_key_pem = pemContent.private_key_pem;
+            if (pemContent.ca_cert_pem) {
+              response.ca_cert_pem = pemContent.ca_cert_pem;
+            }
+          }
+        }
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(response, null, 2),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                success: false,
+                error: error instanceof Error ? error.message : String(error),
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // credential_list - List all stored credentials
+  server.tool(
+    "credential_list",
+    "List all stored EAP-TLS credentials. Returns metadata for each credential " +
+      "(id, identity, description, dates). Use credential_get for full details.",
+    {},
+    async () => {
+      try {
+        const credentials = await credentialStore.list();
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(
+                {
+                  success: true,
+                  credentials: credentials.map((c) => ({
+                    id: c.id,
+                    identity: c.identity,
+                    description: c.description,
+                    created_at: c.created_at,
+                    updated_at: c.updated_at,
+                    has_ca_cert: c.has_ca_cert,
+                  })),
+                  count: credentials.length,
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                success: false,
+                error: error instanceof Error ? error.message : String(error),
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // credential_delete - Delete a stored credential
+  server.tool(
+    "credential_delete",
+    "Delete a stored credential. Removes all certificate files and metadata. " +
+      "This action cannot be undone.",
+    {
+      id: z.string().describe("Credential identifier to delete"),
+    },
+    async ({ id }) => {
+      try {
+        const exists = await credentialStore.exists(id);
+
+        if (!exists) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify({
+                  success: false,
+                  error: `Credential '${id}' not found`,
+                }),
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        const deleted = await credentialStore.delete(id);
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                success: deleted,
+                id,
+                deleted,
+                message: deleted
+                  ? `Credential '${id}' deleted successfully`
+                  : `Failed to delete credential '${id}'`,
+              }),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                success: false,
+                error: error instanceof Error ? error.message : String(error),
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+}

--- a/src/tools/credentials.ts
+++ b/src/tools/credentials.ts
@@ -7,8 +7,8 @@ export function registerCredentialTools(server: McpServer): void {
   server.tool(
     "credential_store",
     "Store EAP-TLS certificates for later use with wifi_connect_tls. " +
-      "Certificates are stored securely on the MCP server. " +
-      "Use credential_id parameter in wifi_connect_tls to connect without passing full PEM content.",
+      "Upload certificates via SCP first, then reference file paths here. " +
+      "Files are validated with openssl before copying to the credential store.",
     {
       id: z
         .string()
@@ -18,12 +18,12 @@ export function registerCredentialTools(server: McpServer): void {
       identity: z
         .string()
         .describe("Identity for EAP authentication (typically CN from client certificate)"),
-      client_cert_pem: z.string().describe("PEM-encoded client certificate"),
-      private_key_pem: z.string().describe("PEM-encoded private key"),
-      ca_cert_pem: z
+      client_cert_path: z.string().describe("Path to client certificate file on MCP server"),
+      private_key_path: z.string().describe("Path to private key file on MCP server"),
+      ca_cert_path: z
         .string()
         .optional()
-        .describe("PEM-encoded CA certificate for server validation"),
+        .describe("Path to CA certificate file on MCP server"),
       private_key_password: z
         .string()
         .optional()
@@ -36,9 +36,9 @@ export function registerCredentialTools(server: McpServer): void {
     async ({
       id,
       identity,
-      client_cert_pem,
-      private_key_pem,
-      ca_cert_pem,
+      client_cert_path,
+      private_key_path,
+      ca_cert_path,
       private_key_password,
       description,
     }) => {
@@ -46,9 +46,9 @@ export function registerCredentialTools(server: McpServer): void {
         const result = await credentialStore.store(
           id,
           identity,
-          client_cert_pem,
-          private_key_pem,
-          ca_cert_pem,
+          client_cert_path,
+          private_key_path,
+          ca_cert_path,
           private_key_password,
           description
         );

--- a/src/tools/wifi.ts
+++ b/src/tools/wifi.ts
@@ -639,7 +639,8 @@ export function registerWifiTools(
       private_key_pem: z.string().describe("PEM-encoded private key"),
       ca_cert_pem: z
         .string()
-        .describe("PEM-encoded CA certificate for server validation"),
+        .optional()
+        .describe("PEM-encoded CA certificate for server validation. If omitted, server certificate is not verified (insecure, for testing only)."),
       private_key_password: z
         .string()
         .optional()


### PR DESCRIPTION
## Summary

- Add EAP-TLS certificate-based WiFi authentication (`wifi_connect_tls`)
- Add credential store for secure certificate management (CRUD operations)
- Implement file path approach to prevent PEM corruption in AI tool calls
- Add `make upload-certs` for SCP-based certificate deployment

## Changes

### New Files
| File | Description |
|------|-------------|
| `src/lib/credential-store.ts` | Credential CRUD operations with openssl validation |
| `src/lib/cert-manager.ts` | Temp certificate file management |
| `src/tools/credentials.ts` | MCP tools: credential_store, credential_get, credential_list, credential_delete |
| `docs/credential-store-design.md` | Design doc for SCP + file path approach |
| `scripts/gen-tls-call.sh` | Helper script for testing |

### Modified Files
| File | Changes |
|------|---------|
| `src/lib/wpa-cli.ts` | Add `connectTls()` method with EAP-TLS wpa_supplicant config |
| `src/tools/wifi.ts` | Add `wifi_connect_tls` tool with credential_id support |
| `src/index.ts` | Register credential tools |
| `Makefile` | Add `upload-certs` target for SCP deployment |
| `.env.example` | Add certificate path configuration |

## New Tools

### wifi_connect_tls
| Parameter | Required | Description |
|-----------|----------|-------------|
| ssid | Yes | Network SSID |
| credential_id | No* | Reference to stored credential |
| identity | No* | Identity (CN from client cert) |
| client_cert_path | No* | Path to client certificate |
| private_key_path | No* | Path to private key |
| ca_cert_path | No | Path to CA certificate |
| private_key_password | No | Passphrase for encrypted key |

*Either `credential_id` OR (`identity` + `client_cert_path` + `private_key_path`) required

### credential_store
| Parameter | Required | Description |
|-----------|----------|-------------|
| id | Yes | Unique credential identifier |
| identity | Yes | EAP identity |
| client_cert_path | Yes | Path to client cert on MCP server |
| private_key_path | Yes | Path to private key on MCP server |
| ca_cert_path | No | Path to CA cert on MCP server |

### credential_get, credential_list, credential_delete
Standard CRUD operations for credential management.

## Architecture

```
Local Machine                    Remote MCP Server
┌─────────────┐                  ┌─────────────────────────────┐
│ certs/      │                  │ /tmp/certs/                 │
│ client.crt  │ ── make ──────>  │   client.crt                │
│ client.key  │    upload-certs  │   client.key                │
│ ca.crt      │                  │   ca.crt                    │
└─────────────┘                  └──────────┬──────────────────┘
                                            │ credential_store
                                            ▼
                                 ┌─────────────────────────────┐
                                 │ ~/.config/wpa-mcp/          │
                                 │   credentials/{id}/         │
                                 │     client.crt (0600)       │
                                 │     client.key (0600)       │
                                 │     ca.crt                  │
                                 │     meta.json               │
                                 └─────────────────────────────┘
```

## Security

- Certificates uploaded via SCP (binary-safe, SSH encrypted)
- Files validated with openssl before storing
- Credential store with 0700 directory, 0600 file permissions
- No PEM content in AI tool calls (prevents corruption)

## Test Plan

- [x] TypeScript builds without errors
- [x] `make upload-certs` successfully uploads certificates
- [x] `credential_store` validates and stores certificates
- [x] `wifi_connect_tls` connects with credential_id
- [x] EAP-TLS handshake completes successfully
- [x] DHCP obtains IP address
- [x] Internet connectivity verified

### Tested Networks
| SSID | Result |
|------|--------|
| `8021x reference` | ✅ Connected |
| `8021x reference direct` | ✅ Connected |
| `8021x fqdn` | ❌ AP→RADIUS issue (not client) |
| `hs20 fqdn` | ❌ AP→RADIUS issue (not client) |

🤖 Generated with [Claude Code](https://claude.ai/code)