### PR TITLE
Add Hotspot 2.0 (HS20/Passpoint) support with EAP-TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,17 +245,29 @@ ip link show | grep -E "^[0-9]+: wl"
 
 #### 2. Disable NetworkManager for WiFi interface (if running)
 
+**Important:** If NetworkManager is managing your WiFi interface, it will interfere with wpa_supplicant connections made by this server. NetworkManager sees the connection but has no matching profile, causing it to disconnect immediately with:
+```
+wpa_supplicant: No network configuration found for the current AP
+wpa_supplicant: CTRL-EVENT-DISCONNECTED ... locally_generated=1
+```
+
 ```bash
 # Check if NetworkManager is managing your interface
 nmcli device status
 
-# If managed, tell NetworkManager to ignore it
+# If managed, tell NetworkManager to ignore it (temporary)
 sudo nmcli device set wlan0 managed no
 
-# Or permanently via config:
-# /etc/NetworkManager/conf.d/99-unmanaged.conf
-# [keyfile]
-# unmanaged-devices=interface-name:wlan0
+# Or permanently via config file (recommended):
+sudo tee /etc/NetworkManager/conf.d/99-unmanaged-wlan0.conf << 'EOF'
+[keyfile]
+unmanaged-devices=interface-name:wlan0
+EOF
+sudo systemctl restart NetworkManager
+
+# Verify it's unmanaged
+nmcli device status | grep wlan0
+# Should show: wlan0  wifi  unmanaged  --
 ```
 
 #### 3. Create wpa_supplicant config

--- a/docs/01_WiFi_Tools.md
+++ b/docs/01_WiFi_Tools.md
@@ -23,7 +23,8 @@ This document provides a complete reference for all WiFi-related MCP tools, incl
 │  wifi_connect                  wifi_scan                        │
 │  wifi_connect_eap              wifi_status                      │
 │  wifi_connect_tls              wifi_list_networks               │
-│  wifi_disconnect               wifi_forget                      │
+│  wifi_hs20_connect (NEW)       wifi_forget                      │
+│  wifi_disconnect                                                │
 │  wifi_reconnect                                                 │
 │                                                                 │
 │  Diagnostics                   Credentials                      │
@@ -189,6 +190,69 @@ Connect using EAP-TLS certificate-based authentication (no password).
   "identity": "device.example.com"
 }
 ```
+
+---
+
+### wifi_hs20_connect
+
+Connect to Hotspot 2.0 (Passpoint) networks using EAP-TLS and ANQP auto-discovery.
+
+**Overview:**
+Hotspot 2.0 (HS20/Passpoint) enables automatic discovery and connection to compatible 
+networks using ANQP (Access Network Query Protocol). Instead of specifying an SSID, 
+you provide realm and domain, and wpa_supplicant automatically finds and connects 
+to matching networks.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| credential_id | string | Yes | Reference to stored credential |
+| realm | string | Yes | Home realm for NAI matching (e.g., 'corp.example.com') |
+| domain | string | Yes | Home domain for domain list matching |
+| priority | number | No | Selection priority (default: 1) |
+| interface | string | No | WiFi interface (default: wlan0) |
+
+**Example:**
+```json
+{
+  "credential_id": "user01-corp",
+  "realm": "corp.example.com",
+  "domain": "example.com"
+}
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "Connected via HS20",
+  "credential_id": "user01-corp",
+  "realm": "corp.example.com",
+  "domain": "example.com",
+  "status": {
+    "wpa_state": "COMPLETED",
+    "ssid": "Passpoint-Network",
+    "ip_address": "10.0.1.50"
+  }
+}
+```
+
+**How It Works:**
+1. Creates an HS20 credential with realm, domain, and EAP-TLS settings
+2. Triggers `interworking_select auto` for ANQP discovery
+3. wpa_supplicant scans for HS20 networks and queries them via ANQP
+4. Networks matching the realm/domain are automatically selected
+5. EAP-TLS authentication proceeds with stored certificates
+6. DHCP obtains IP address on successful connection
+
+**Troubleshooting:**
+- Use `wifi_get_debug_logs` with `filter="eap"` for authentication issues
+- Connection timeout usually means no matching HS20 network was found
+- Verify realm/domain match what the network advertises via ANQP
+
+**Related:**
+- [12_HS20_Design.md](./12_HS20_Design.md) - Detailed HS20 design document
 
 ---
 
@@ -675,3 +739,4 @@ Delete a stored credential.
 - [00_Architecture.md](./00_Architecture.md) - System architecture
 - [10_EAP-TLS_Design.md](./10_EAP-TLS_Design.md) - EAP-TLS design
 - [11_Credential_Store_Design.md](./11_Credential_Store_Design.md) - Credential storage design
+- [12_HS20_Design.md](./12_HS20_Design.md) - Hotspot 2.0 (Passpoint) design

--- a/docs/12_HS20_Design.md
+++ b/docs/12_HS20_Design.md
@@ -1,0 +1,347 @@
+# Hotspot 2.0 (HS20) Support Design
+
+**Status:** Complete  
+**Created:** 2026-01-14  
+**Related:** [01_WiFi_Tools.md](./01_WiFi_Tools.md), [10_EAP-TLS_Design.md](./10_EAP-TLS_Design.md)
+
+---
+
+## Goal
+
+Add Hotspot 2.0 (Passpoint) support to wpa-mcp, enabling automatic network discovery and seamless connection via ANQP queries. Uses existing credential_store for EAP-TLS certificates with additional realm/domain parameters.
+
+---
+
+## Background
+
+### What is Hotspot 2.0?
+
+Hotspot 2.0 (HS20), also known as Passpoint, is defined by IEEE 802.11u. It enables seamless WiFi roaming similar to cellular networks:
+
+- **Automatic discovery** via ANQP (Access Network Query Protocol)
+- **Credential-based matching** (realm/domain) instead of SSID selection
+- **Seamless roaming** across multiple networks with same credentials
+
+### Key Differences from Standard EAP-TLS
+
+| Aspect | Standard EAP-TLS | HS20 EAP-TLS |
+|--------|------------------|--------------|
+| Network Selection | Manual (SSID required) | Automatic (realm/domain matching) |
+| Configuration | `network={}` block | `cred={}` block |
+| Discovery | None | ANQP queries |
+| Scope | Single SSID | Multiple networks |
+
+---
+
+## User Flow
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    wifi_hs20_connect                            │
+│                                                                 │
+│  Input: credential_id, realm, domain                            │
+└─────────────────────────────┬───────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│         Load certs from credential_store (existing)             │
+│                                                                 │
+│  ~/.config/wpa-mcp/credentials/<id>/                            │
+│  ├── client.crt                                                 │
+│  ├── client.key                                                 │
+│  └── ca.crt                                                     │
+└─────────────────────────────┬───────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│              Add HS20 credential via wpa_cli                    │
+│                                                                 │
+│  wpa_cli add_cred → returns cred_id                             │
+│  wpa_cli set_cred <id> realm "corp.example.com"                 │
+│  wpa_cli set_cred <id> domain "example.com"                     │
+│  wpa_cli set_cred <id> eap TLS                                  │
+│  wpa_cli set_cred <id> client_cert "/path/to/client.crt"        │
+│  wpa_cli set_cred <id> private_key "/path/to/client.key"        │
+│  wpa_cli set_cred <id> ca_cert "/path/to/ca.crt"                │
+└─────────────────────────────┬───────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│              ANQP Network Discovery                             │
+│                                                                 │
+│  wpa_cli interworking_select auto                               │
+│                                                                 │
+│  wpa_supplicant:                                                │
+│  1. Queries all visible APs via ANQP                            │
+│  2. Retrieves NAI Realm List, Domain Name List                  │
+│  3. Matches against credential's realm/domain                   │
+│  4. Auto-selects best matching AP                               │
+│  5. Initiates EAP-TLS authentication                            │
+└─────────────────────────────┬───────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│              Wait for connection + DHCP                         │
+│                                                                 │
+│  waitForState('COMPLETED')                                      │
+│  dhcpManager.start() → obtain IP address                        │
+└─────────────────────────────┬───────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│              Return result                                      │
+│                                                                 │
+│  { success: true, ssid: "...", ip_address: "10.0.1.50" }        │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                      wifi_hs20_connect Tool                     │
+│                      src/tools/wifi.ts                          │
+├─────────────────────────────────────────────────────────────────┤
+│  Input:                                                         │
+│  • credential_id (references credential_store)                  │
+│  • realm (required)                                             │
+│  • domain (required)                                            │
+│  • priority (optional, default: 1)                              │
+└───────────────────────────────┬─────────────────────────────────┘
+                                │
+            ┌───────────────────┴───────────────────┐
+            │                                       │
+            ▼                                       ▼
+┌───────────────────────┐               ┌───────────────────────┐
+│   credential_store    │               │       WpaCli          │
+│   src/lib/credential- │               │   src/lib/wpa-cli.ts  │
+│       store.ts        │               │                       │
+├───────────────────────┤               ├───────────────────────┤
+│ get(credential_id)    │               │ addCred()             │
+│ • Returns cert paths  │               │ setCred()             │
+│ • Returns identity    │               │ removeCred()          │
+│ • Returns key password│               │ interworkingSelect()  │
+└───────────────────────┘               │ connectHs20()         │
+                                        └───────────────────────┘
+                                                    │
+                                                    ▼
+                                        ┌───────────────────────┐
+                                        │    wpa_supplicant     │
+                                        │                       │
+                                        │ • interworking=1      │
+                                        │ • hs20=1              │
+                                        │ • ANQP queries        │
+                                        │ • Auto network select │
+                                        └───────────────────────┘
+```
+
+---
+
+## API: wifi_hs20_connect
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| credential_id | string | Yes | Reference to stored EAP-TLS credential |
+| realm | string | Yes | Home realm for NAI matching (e.g., `corp.example.com`) |
+| domain | string | Yes | Home domain for domain list matching (e.g., `example.com`) |
+| priority | number | No | Selection priority when multiple networks match (default: 1) |
+| interface | string | No | WiFi interface (default: wlan0) |
+
+### Example Request
+
+```json
+{
+  "credential_id": "my-corp-cert",
+  "realm": "corp.example.com",
+  "domain": "example.com"
+}
+```
+
+### Example Response (Success)
+
+```json
+{
+  "success": true,
+  "message": "Connected via HS20",
+  "credential_id": "my-corp-cert",
+  "realm": "corp.example.com",
+  "domain": "example.com",
+  "status": {
+    "wpaState": "COMPLETED",
+    "ssid": "CorpWiFi-Passpoint",
+    "bssid": "aa:bb:cc:dd:ee:ff",
+    "ipAddress": "10.0.1.50",
+    "keyManagement": "WPA2/IEEE 802.1X/EAP"
+  }
+}
+```
+
+### Example Response (No Network Found)
+
+```json
+{
+  "success": false,
+  "error": "No HS20 network found matching realm/domain",
+  "realm": "corp.example.com",
+  "domain": "example.com"
+}
+```
+
+---
+
+## Design Decisions
+
+### 1. Implementation via wpa_cli (not config file)
+
+**Choice:** Use `wpa_cli add_cred` / `set_cred` commands
+
+**Rationale (per CLAUDE.md):**
+- **Consistency** - Matches existing `connectTls` pattern using `add_network` / `set_network`
+- **Clean rollback** - Can `remove_cred` on error (like `remove_network`)
+- **Separation of concerns** - WpaCli class stays focused on wpa_cli commands
+- **No file I/O** - Avoids config file parsing complexity
+
+### 2. Reuse credential_store
+
+**Choice:** Load certificates from existing credential_store
+
+**Rationale:**
+- **No duplication** - Same certs work for both `wifi_connect_tls` and `wifi_hs20_connect`
+- **Consistency** - User manages certs in one place
+- **Simpler UX** - Store once, use for multiple connection types
+
+### 3. Basic HS20 parameters only
+
+**Choice:** Support `realm` and `domain` only, no OI (Organization Identifier)
+
+**Rationale:**
+- **User requirement** - Single organization use case, no roaming partners
+- **Simplicity** - OI adds complexity for advanced roaming scenarios
+
+---
+
+## Error Handling
+
+Following CLAUDE.md guidelines - cleanup on failure with context-rich errors:
+
+```typescript
+async connectHs20(
+  realm: string,
+  domain: string,
+  identity: string,
+  clientCertPath: string,
+  privateKeyPath: string,
+  caCertPath?: string,
+  privateKeyPassword?: string,
+  priority?: number
+): Promise<void> {
+  const credId = await this.addCred();
+
+  try {
+    await this.setCred(credId, 'realm', realm);
+    await this.setCred(credId, 'domain', domain);
+    await this.setCred(credId, 'eap', 'TLS');
+    await this.setCred(credId, 'client_cert', clientCertPath);
+    await this.setCred(credId, 'private_key', privateKeyPath);
+    // ... additional params
+
+    await this.interworkingSelect(true);
+  } catch (error) {
+    // Cleanup on failure (same pattern as connectTls)
+    await this.removeCred(credId).catch(() => {});
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`HS20 connection to ${realm} failed: ${message}`);
+  }
+}
+```
+
+---
+
+## wpa_supplicant Requirements
+
+HS20 requires wpa_supplicant with these build options:
+
+```
+CONFIG_INTERWORKING=y
+CONFIG_HS20=y
+```
+
+And runtime configuration:
+
+```conf
+interworking=1
+hs20=1
+```
+
+---
+
+## Usage Example
+
+### Step 1: Store EAP-TLS Credential
+
+```json
+{
+  "tool": "credential_store",
+  "params": {
+    "id": "corp-cert",
+    "identity": "user@corp.example.com",
+    "client_cert_path": "/tmp/certs/client.crt",
+    "private_key_path": "/tmp/certs/client.key",
+    "ca_cert_path": "/tmp/certs/ca.crt"
+  }
+}
+```
+
+### Step 2: Connect via HS20
+
+```json
+{
+  "tool": "wifi_hs20_connect",
+  "params": {
+    "credential_id": "corp-cert",
+    "realm": "corp.example.com",
+    "domain": "example.com"
+  }
+}
+```
+
+### Step 3: Verify Connection
+
+```json
+{
+  "tool": "wifi_status"
+}
+```
+
+---
+
+## Debugging
+
+Use `wifi_get_debug_logs` with filter `eap` to troubleshoot:
+
+```json
+{
+  "tool": "wifi_get_debug_logs",
+  "params": {
+    "filter": "eap",
+    "since_last_command": true
+  }
+}
+```
+
+Look for:
+- `INTERWORKING-AP` events (discovered networks)
+- `ANQP` messages (query/response)
+- `EAP` state transitions
+
+---
+
+## Related Documents
+
+- [01_WiFi_Tools.md](./01_WiFi_Tools.md) - WiFi tool reference
+- [10_EAP-TLS_Design.md](./10_EAP-TLS_Design.md) - EAP-TLS design
+- [11_Credential_Store_Design.md](./11_Credential_Store_Design.md) - Credential storage

--- a/src/lib/wpa-cli.ts
+++ b/src/lib/wpa-cli.ts
@@ -607,27 +607,27 @@ export class WpaCli {
     const credId = await this.addCred();
 
     try {
-      // Set realm (quoted string)
-      await this.setCred(credId, "realm", `"${realm}"`);
+      // Set realm (quoted string - use single quotes to pass double quotes through shell)
+      await this.setCred(credId, "realm", `'"${realm}"'`);
 
       // Set domain (quoted string)
-      await this.setCred(credId, "domain", `"${domain}"`);
+      await this.setCred(credId, "domain", `'"${domain}"'`);
 
       // Set EAP method to TLS
       await this.setCred(credId, "eap", "TLS");
 
       // Set identity (quoted string)
-      await this.setCred(credId, "username", `"${identity}"`);
+      await this.setCred(credId, "username", `'"${identity}"'`);
 
       // Set client certificate (quoted path)
-      await this.setCred(credId, "client_cert", `"${clientCertPath}"`);
+      await this.setCred(credId, "client_cert", `'"${clientCertPath}"'`);
 
       // Set private key (quoted path)
-      await this.setCred(credId, "private_key", `"${privateKeyPath}"`);
+      await this.setCred(credId, "private_key", `'"${privateKeyPath}"'`);
 
       // Set CA certificate if provided (quoted path)
       if (caCertPath) {
-        await this.setCred(credId, "ca_cert", `"${caCertPath}"`);
+        await this.setCred(credId, "ca_cert", `'"${caCertPath}"'`);
       }
 
       // Set private key password if provided (quoted string)
@@ -635,7 +635,7 @@ export class WpaCli {
         await this.setCred(
           credId,
           "private_key_passwd",
-          `"${privateKeyPassword}"`,
+          `'"${privateKeyPassword}"'`,
         );
       }
 

--- a/src/lib/wpa-cli.ts
+++ b/src/lib/wpa-cli.ts
@@ -525,4 +525,132 @@ export class WpaCli {
       ),
     };
   }
+
+  // ========================================
+  // Hotspot 2.0 (HS20) Methods
+  // ========================================
+
+  /**
+   * Add a new credential for HS20/Passpoint.
+   * Returns the credential ID assigned by wpa_supplicant.
+   */
+  async addCred(): Promise<number> {
+    const result = await this.run("add_cred");
+    const credId = parseInt(result, 10);
+
+    if (isNaN(credId)) {
+      throw new Error(`Failed to add credential: ${result}`);
+    }
+
+    return credId;
+  }
+
+  /**
+   * Set a credential parameter.
+   * @param credId - Credential ID from addCred()
+   * @param param - Parameter name (e.g., 'realm', 'domain', 'eap')
+   * @param value - Parameter value
+   */
+  async setCred(credId: number, param: string, value: string): Promise<void> {
+    const result = await this.run(`set_cred ${credId} ${param} ${value}`);
+    if (!result.includes("OK")) {
+      throw new Error(`Failed to set credential ${param}: ${result}`);
+    }
+  }
+
+  /**
+   * Remove a credential.
+   * @param credId - Credential ID to remove
+   */
+  async removeCred(credId: number): Promise<void> {
+    const result = await this.run(`remove_cred ${credId}`);
+    if (!result.includes("OK")) {
+      throw new Error(`Failed to remove credential: ${result}`);
+    }
+  }
+
+  /**
+   * Trigger interworking (ANQP) network selection.
+   * @param auto - If true, automatically connect to matching network
+   */
+  async interworkingSelect(auto: boolean = true): Promise<void> {
+    const command = auto ? "interworking_select auto" : "interworking_select";
+    const result = await this.run(command);
+    if (!result.includes("OK")) {
+      throw new Error(`Interworking select failed: ${result}`);
+    }
+  }
+
+  /**
+   * Connect to a Hotspot 2.0 (Passpoint) network using EAP-TLS credentials.
+   * Uses ANQP to discover and connect to matching networks.
+   *
+   * @param realm - Home realm for NAI matching (e.g., "corp.example.com")
+   * @param domain - Home domain for domain list matching (e.g., "example.com")
+   * @param identity - User identity (e.g., "user@example.com")
+   * @param clientCertPath - Path to client certificate file
+   * @param privateKeyPath - Path to private key file
+   * @param caCertPath - Path to CA certificate file (optional)
+   * @param privateKeyPassword - Password for encrypted private key (optional)
+   * @param priority - Selection priority when multiple networks match (optional)
+   */
+  async connectHs20(
+    realm: string,
+    domain: string,
+    identity: string,
+    clientCertPath: string,
+    privateKeyPath: string,
+    caCertPath?: string,
+    privateKeyPassword?: string,
+    priority?: number,
+  ): Promise<void> {
+    const credId = await this.addCred();
+
+    try {
+      // Set realm (quoted string)
+      await this.setCred(credId, "realm", `"${realm}"`);
+
+      // Set domain (quoted string)
+      await this.setCred(credId, "domain", `"${domain}"`);
+
+      // Set EAP method to TLS
+      await this.setCred(credId, "eap", "TLS");
+
+      // Set identity (quoted string)
+      await this.setCred(credId, "username", `"${identity}"`);
+
+      // Set client certificate (quoted path)
+      await this.setCred(credId, "client_cert", `"${clientCertPath}"`);
+
+      // Set private key (quoted path)
+      await this.setCred(credId, "private_key", `"${privateKeyPath}"`);
+
+      // Set CA certificate if provided (quoted path)
+      if (caCertPath) {
+        await this.setCred(credId, "ca_cert", `"${caCertPath}"`);
+      }
+
+      // Set private key password if provided (quoted string)
+      if (privateKeyPassword) {
+        await this.setCred(
+          credId,
+          "private_key_passwd",
+          `"${privateKeyPassword}"`,
+        );
+      }
+
+      // Set priority if provided
+      if (priority !== undefined) {
+        await this.setCred(credId, "priority", String(priority));
+      }
+
+      // Trigger ANQP discovery and auto-connect
+      await this.interworkingSelect(true);
+    } catch (error) {
+      // Clean up on failure (same pattern as connectTls)
+      await this.removeCred(credId).catch(() => {});
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`HS20 connection failed: ${message}`);
+    }
+  }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,21 +26,21 @@ export interface ConnectionStatus {
 
 // MAC Address Randomization Types
 export type MacAddressMode =
-  | 'device'            // Use real device MAC (wpa_supplicant value: 0)
-  | 'random'            // New random MAC each connection (wpa_supplicant value: 1)
-  | 'persistent-random' // Same random MAC across reboots (wpa_supplicant value: 2)
-  | 'specific';         // User-provided MAC address
+  | "device" // Use real device MAC (wpa_supplicant value: 0)
+  | "random" // New random MAC each connection (wpa_supplicant value: 1)
+  | "persistent-random" // Same random MAC across reboots (wpa_supplicant value: 2)
+  | "specific"; // User-provided MAC address
 
 export type PreassocMacMode =
-  | 'disabled'          // Use real MAC during scan (wpa_supplicant value: 0)
-  | 'random'            // Random MAC during scan (wpa_supplicant value: 1)
-  | 'persistent-random';// Persistent random during scan (wpa_supplicant value: 2)
+  | "disabled" // Use real MAC during scan (wpa_supplicant value: 0)
+  | "random" // Random MAC during scan (wpa_supplicant value: 1)
+  | "persistent-random"; // Persistent random during scan (wpa_supplicant value: 2)
 
 export interface MacAddressConfig {
   mode: MacAddressMode;
-  address?: string;            // Required only when mode is 'specific'
+  address?: string; // Required only when mode is 'specific'
   preassocMode?: PreassocMacMode;
-  randAddrLifetime?: number;   // Seconds before rotating random MAC (default: 60)
+  randAddrLifetime?: number; // Seconds before rotating random MAC (default: 60)
 }
 
 // Connectivity Types
@@ -64,4 +64,11 @@ export interface ScriptInfo {
 
 export interface ScriptVariables {
   [key: string]: string;
+}
+
+// Hotspot 2.0 (HS20) Types
+export interface Hs20Config {
+  realm: string; // Home realm for NAI matching (e.g., "corp.example.com")
+  domain: string; // Home domain for domain list matching (e.g., "example.com")
+  priority?: number; // Selection priority when multiple networks match (default: 1)
 }


### PR DESCRIPTION
## Summary

Implements Hotspot 2.0 (Passpoint) support using EAP-TLS certificate authentication.

## Changes

### New Tool: `wifi_hs20_connect`

Connect to HS20/Passpoint networks using ANQP auto-discovery:

```json
{
  "credential_id": "my-cert",
  "realm": "corp.example.com",
  "domain": "example.com"
}
```

### New WpaCli Methods

- `addCred()` - Add HS20 credential
- `setCred()` - Set credential parameter
- `removeCred()` - Remove credential
- `interworkingSelect()` - Trigger ANQP discovery
- `connectHs20()` - Full HS20 connection flow

### Documentation

- New: `docs/12_HS20_Design.md` - Complete design document
- Updated: `docs/01_WiFi_Tools.md` - Added wifi_hs20_connect reference
- Updated: `README.md` - Improved NetworkManager troubleshooting

## Implementation Notes

- Follows existing `connectTls()` pattern per CLAUDE.md guidelines
- Uses wpa_cli commands (not config file) for consistency
- Reuses `credential_store` for certificate management
- Cleanup on failure via `removeCred()`

## Testing

- Build passes: `npm run build`
- Ready for manual testing with HS20-enabled AP

## Related

- Design doc: [docs/12_HS20_Design.md](docs/12_HS20_Design.md)