### PR TITLE
Improve HS20 timeout handling and daemon restart reliability

### DIFF
--- a/src/tools/wifi.ts
+++ b/src/tools/wifi.ts
@@ -1055,6 +1055,8 @@ export function registerWifiTools(
         // 3. Restart daemon to apply config (auto_interworking will trigger ANQP)
         if (daemon) {
           await daemon.restart();
+          // Wait for daemon to initialize and start scanning
+          await new Promise((resolve) => setTimeout(resolve, 3000));
         }
 
         // 4. Wait for auto-connection (default 60 seconds - ANQP discovery can take 20-30s)
@@ -1084,6 +1086,7 @@ export function registerWifiTools(
                   {
                     success: true,
                     message: "Connected via HS20 (config-based)",
+                    interface: targetIface,
                     credential_id: credential_id,
                     realm: realm,
                     domain: domain,
@@ -1112,8 +1115,9 @@ export function registerWifiTools(
                 {
                   success: reached,
                   message: reached
-                    ? "Connected via HS20 (config-based)"
+                    ? "Connected via HS20 (config-based, no DHCP manager)"
                     : "HS20 connection timeout (no matching network found or ANQP failed)",
+                  interface: targetIface,
                   credential_id: credential_id,
                   realm: realm,
                   domain: domain,


### PR DESCRIPTION
## Summary

This PR improves reliability of Hotspot 2.0 (HS20) connections and daemon restart behavior.

## Changes

### Improve HS20 timeout handling for slow ANQP discovery
- ANQP discovery with multiple APs can take 20-30+ seconds
- Added configurable `timeout` parameter to `wifi_hs20_connect` tool (default: 60s)
- Updated tool description to document timeout behavior

### Add 3s delay after daemon restart for wpa_supplicant init
- wpa_supplicant needs time to initialize after restart
- Added delay to prevent race conditions when immediately issuing commands after restart

## Testing

- Tested HS20 connections in environments with multiple access points
- Verified daemon restart reliability with immediate subsequent operations

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances HS20 (Passpoint) connection reliability and configurability.
> 
> - Adds configurable `timeout` (default 60s) to `wifi_hs20_connect`; updates descriptions and surfaces `timeout_seconds` and `interface` in responses
> - Waits 3s after `wpa_supplicant` daemon restart to allow initialization before scanning
> - Extends connection wait logic: uses `timeout` for `waitForState`, performs a post-timeout status check, and proceeds with DHCP on late success
> - Improves result messages (e.g., "config-based, no DHCP manager") and provides a hint to increase timeout on discovery-heavy environments
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac711a18bc4707e2339ce10ea1430b3273af5324. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->