### PR TITLE
Add BSSID parameter to WiFi connection tools

### DIFF
--- a/src/lib/wpa-cli.ts
+++ b/src/lib/wpa-cli.ts
@@ -110,6 +110,7 @@ export class WpaCli {
     ssid: string,
     psk?: string,
     macConfig?: MacAddressConfig,
+    bssid?: string,
   ): Promise<void> {
     // Add new network
     const networkIdStr = await this.run("add_network");
@@ -126,6 +127,16 @@ export class WpaCli {
       );
       if (!ssidResult.includes("OK")) {
         throw new Error(`Failed to set SSID: ${ssidResult}`);
+      }
+
+      // Set BSSID if specified (for connecting to specific AP)
+      if (bssid) {
+        const bssidResult = await this.run(
+          `set_network ${networkId} bssid ${bssid}`,
+        );
+        if (!bssidResult.includes("OK")) {
+          throw new Error(`Failed to set BSSID: ${bssidResult}`);
+        }
       }
 
       if (psk) {
@@ -179,6 +190,7 @@ export class WpaCli {
     eapMethod: string = "PEAP",
     phase2: string = "MSCHAPV2",
     macConfig?: MacAddressConfig,
+    bssid?: string,
   ): Promise<void> {
     // Add new network
     const networkIdStr = await this.run("add_network");
@@ -195,6 +207,16 @@ export class WpaCli {
       );
       if (!ssidResult.includes("OK")) {
         throw new Error(`Failed to set SSID: ${ssidResult}`);
+      }
+
+      // Set BSSID if specified (for connecting to specific AP)
+      if (bssid) {
+        const bssidResult = await this.run(
+          `set_network ${networkId} bssid ${bssid}`,
+        );
+        if (!bssidResult.includes("OK")) {
+          throw new Error(`Failed to set BSSID: ${bssidResult}`);
+        }
       }
 
       // Set key management to WPA-EAP
@@ -481,6 +503,7 @@ export class WpaCli {
     caCertPath?: string,
     privateKeyPassword?: string,
     macConfig?: MacAddressConfig,
+    bssid?: string,
   ): Promise<void> {
     const networkIdStr = await this.run("add_network");
     const networkId = parseInt(networkIdStr, 10);
@@ -496,6 +519,16 @@ export class WpaCli {
       );
       if (!ssidResult.includes("OK")) {
         throw new Error(`Failed to set SSID: ${ssidResult}`);
+      }
+
+      // Set BSSID if specified (for connecting to specific AP)
+      if (bssid) {
+        const bssidResult = await this.run(
+          `set_network ${networkId} bssid ${bssid}`,
+        );
+        if (!bssidResult.includes("OK")) {
+          throw new Error(`Failed to set BSSID: ${bssidResult}`);
+        }
       }
 
       // Set key management to WPA-EAP

--- a/src/tools/wifi.ts
+++ b/src/tools/wifi.ts
@@ -128,6 +128,13 @@ export function registerWifiTools(
           "Seconds before rotating random MAC address (default: 60). " +
             "Only applies when mac_mode is random or persistent-random.",
         ),
+      bssid: z
+        .string()
+        .optional()
+        .describe(
+          "BSSID of specific access point to connect to (format: aa:bb:cc:dd:ee:ff). " +
+            "Use when multiple APs share the same SSID.",
+        ),
     },
     async ({
       ssid,
@@ -137,6 +144,7 @@ export function registerWifiTools(
       mac_address,
       preassoc_mac_mode,
       rand_addr_lifetime,
+      bssid,
     }) => {
       try {
         // Clear HS20 config if active (switching from HS20 to direct connection)
@@ -162,7 +170,7 @@ export function registerWifiTools(
           };
         }
 
-        await wpa.connect(ssid, password, macConfig);
+        await wpa.connect(ssid, password, macConfig, bssid);
 
         // Poll for connection completion (15 seconds)
         const { reached, status } = await wpa.waitForState("COMPLETED", 15000);
@@ -276,6 +284,13 @@ export function registerWifiTools(
           "Seconds before rotating random MAC address (default: 60). " +
             "Only applies when mac_mode is random or persistent-random.",
         ),
+      bssid: z
+        .string()
+        .optional()
+        .describe(
+          "BSSID of specific access point to connect to (format: aa:bb:cc:dd:ee:ff). " +
+            "Use when multiple APs share the same SSID.",
+        ),
     },
     async ({
       ssid,
@@ -288,6 +303,7 @@ export function registerWifiTools(
       mac_address,
       preassoc_mac_mode,
       rand_addr_lifetime,
+      bssid,
     }) => {
       try {
         // Clear HS20 config if active (switching from HS20 to direct connection)
@@ -320,6 +336,7 @@ export function registerWifiTools(
           eap_method || "PEAP",
           phase2 || "MSCHAPV2",
           macConfig,
+          bssid,
         );
 
         // Poll for connection completion (15 seconds)
@@ -742,6 +759,13 @@ export function registerWifiTools(
           "Seconds before rotating random MAC address (default: 60). " +
             "Only applies when mac_mode is random or persistent-random.",
         ),
+      bssid: z
+        .string()
+        .optional()
+        .describe(
+          "BSSID of specific access point to connect to (format: aa:bb:cc:dd:ee:ff). " +
+            "Use when multiple APs share the same SSID.",
+        ),
     },
     async ({
       ssid,
@@ -756,6 +780,7 @@ export function registerWifiTools(
       mac_address,
       preassoc_mac_mode,
       rand_addr_lifetime,
+      bssid,
     }) => {
       // Resolve certificate paths and identity
       let clientCertPath: string;
@@ -879,6 +904,7 @@ export function registerWifiTools(
           caCertPath,
           resolvedKeyPassword,
           macConfig,
+          bssid,
         );
 
         // Poll for connection completion (15 seconds)


### PR DESCRIPTION
## Summary
- Add optional `bssid` parameter to `wifi_connect`, `wifi_connect_eap`, and `wifi_connect_tls` tools
- Allows connecting to a specific access point when multiple APs share the same SSID
- Useful for testing, avoiding roaming, or preventing SSID spoofing

## Changes
- **src/lib/wpa-cli.ts**: Added `bssid` parameter to `connect()`, `connectEap()`, and `connectTls()` methods
- **src/tools/wifi.ts**: Added `bssid` field to tool schemas and handlers

## Test plan
- [x] Scan networks to identify SSIDs with multiple BSSIDs
- [x] Connect to specific BSSID using `wifi_connect_tls`
- [x] Verify connection status shows the requested BSSID
- [x] Test switching between different BSSIDs of the same SSID

🤖 Generated with [Claude Code](https://claude.ai/code)