### PR TITLE
Add MAC address randomization support for HS20 connections

### DIFF
--- a/src/lib/wpa-config.ts
+++ b/src/lib/wpa-config.ts
@@ -3,8 +3,17 @@ import { join } from "path";
 import { randomBytes } from "crypto";
 import { exec } from "child_process";
 import { promisify } from "util";
+import type { MacAddressMode, PreassocMacMode } from "../types.js";
+import { macModeToGlobalWpaValue } from "./mac-utils.js";
 
 const execAsync = promisify(exec);
+
+export interface GlobalMacConfigOpts {
+  macMode: MacAddressMode;
+  macAddress?: string;
+  preassocMacMode?: PreassocMacMode;
+  randAddrLifetime?: number;
+}
 
 export interface Hs20CredentialOpts {
   realm: string;
@@ -188,6 +197,8 @@ export class WpaConfig {
 
   /**
    * Remove all HS20 credentials from config.
+   * Also resets global MAC settings to prevent them from
+   * affecting non-HS20 connections.
    */
   async clearHs20Credentials(): Promise<boolean> {
     const content = await this.read();
@@ -196,14 +207,18 @@ export class WpaConfig {
     const credBlockRegex = /\n*cred=\{[^}]+\}/gs;
     const newContent = content.replace(credBlockRegex, "");
 
+    let credCleared = false;
     if (newContent !== content) {
       const cleanedContent = newContent.replace(/\n{3,}/g, "\n\n").trimEnd() + "\n";
       await this.write(cleanedContent);
       console.log("Cleared all HS20 credentials");
-      return true;
+      credCleared = true;
     }
 
-    return false;
+    // Also reset global MAC settings
+    const macCleared = await this.resetGlobalMacConfig();
+
+    return credCleared || macCleared;
   }
 
   /**
@@ -248,5 +263,126 @@ export class WpaConfig {
       hs20: /^hs20=1$/m.test(content),
       credentialCount: (content.match(/cred=\{/g) || []).length,
     };
+  }
+
+  /**
+   * Set global MAC address configuration in wpa_supplicant.conf.
+   * Used for HS20/Passpoint connections where network ID is unknown
+   * (auto-created by ANQP discovery).
+   *
+   * Settings written:
+   * - mac_addr: MAC mode for connections (0=device, 1=random, 2=persistent, 3=specific)
+   * - preassoc_mac_addr: MAC mode during scanning
+   * - rand_addr_lifetime: Seconds before rotating random MAC
+   * - gas_rand_mac_addr: MAC mode for GAS/ANQP frames (important for HS20 privacy)
+   * - gas_rand_addr_lifetime: Rotation interval for GAS frames
+   * - mac_value: Specific MAC address (only when mac_addr=3)
+   */
+  async setGlobalMacConfig(opts: GlobalMacConfigOpts): Promise<void> {
+    const globalConfig = macModeToGlobalWpaValue(
+      opts.macMode,
+      opts.macAddress,
+      opts.preassocMacMode,
+      opts.randAddrLifetime
+    );
+
+    let content = await this.read();
+    const lifetime = opts.randAddrLifetime ?? 60;
+
+    // Build list of settings to add/update
+    const settings: { key: string; value: string }[] = [
+      { key: "mac_addr", value: globalConfig.macAddr },
+    ];
+
+    // Add preassoc_mac_addr if specified
+    if (globalConfig.preassocMacAddr !== undefined) {
+      settings.push({ key: "preassoc_mac_addr", value: globalConfig.preassocMacAddr });
+    }
+
+    // Add specific MAC value if using specific mode
+    if (globalConfig.macValue) {
+      settings.push({ key: "mac_value", value: globalConfig.macValue });
+    }
+
+    // Add lifetime for random/persistent modes
+    if (globalConfig.macAddr === "1" || globalConfig.macAddr === "2") {
+      settings.push({ key: "rand_addr_lifetime", value: String(lifetime) });
+    }
+
+    // Configure GAS/ANQP MAC settings for HS20 privacy
+    // Match connection MAC mode for consistency
+    if (globalConfig.macAddr === "3") {
+      // Specific MAC - disable GAS randomization
+      settings.push({ key: "gas_rand_mac_addr", value: "0" });
+    } else {
+      // Use same mode as connection MAC for GAS frames
+      settings.push({ key: "gas_rand_mac_addr", value: globalConfig.macAddr });
+      if (globalConfig.macAddr === "1" || globalConfig.macAddr === "2") {
+        settings.push({ key: "gas_rand_addr_lifetime", value: String(lifetime) });
+      }
+    }
+
+    // Apply each setting
+    for (const { key, value } of settings) {
+      const regex = new RegExp(`^${key}=.*$`, "m");
+      if (regex.test(content)) {
+        // Update existing value
+        content = content.replace(regex, `${key}=${value}`);
+        console.log("Updated global MAC setting", { key, value });
+      } else {
+        // Add after ctrl_interface line or at end of global section
+        const ctrlMatch = content.match(/^ctrl_interface=.+$/m);
+        if (ctrlMatch) {
+          const insertPos = ctrlMatch.index! + ctrlMatch[0].length;
+          content =
+            content.slice(0, insertPos) +
+            `\n${key}=${value}` +
+            content.slice(insertPos);
+        } else {
+          content = `${key}=${value}\n` + content;
+        }
+        console.log("Added global MAC setting", { key, value });
+      }
+    }
+
+    await this.write(content);
+  }
+
+  /**
+   * Remove all global MAC address settings from wpa_supplicant.conf.
+   * Called when clearing HS20 credentials to prevent MAC settings
+   * from leaking to non-HS20 connections.
+   */
+  async resetGlobalMacConfig(): Promise<boolean> {
+    let content = await this.read();
+    let modified = false;
+
+    // List of MAC-related global settings to remove
+    const macSettings = [
+      "mac_addr",
+      "mac_value",
+      "preassoc_mac_addr",
+      "rand_addr_lifetime",
+      "gas_rand_mac_addr",
+      "gas_rand_addr_lifetime",
+    ];
+
+    for (const key of macSettings) {
+      const regex = new RegExp(`^${key}=.*\n?`, "gm");
+      const newContent = content.replace(regex, "");
+      if (newContent !== content) {
+        content = newContent;
+        modified = true;
+        console.log("Removed global MAC setting", { key });
+      }
+    }
+
+    if (modified) {
+      // Clean up extra blank lines
+      const cleanedContent = content.replace(/\n{3,}/g, "\n\n").trimEnd() + "\n";
+      await this.write(cleanedContent);
+    }
+
+    return modified;
   }
 }


### PR DESCRIPTION
## Summary

- Add MAC address randomization parameters to `wifi_hs20_connect` tool (`mac_mode`, `mac_address`, `preassoc_mac_mode`, `rand_addr_lifetime`)
- Implement global MAC config in `wpa_supplicant.conf` for HS20 connections (since network IDs are auto-discovered via ANQP)
- Auto-clear MAC settings when clearing HS20 credentials to prevent leakage to non-HS20 connections

## Test plan

- [ ] Test HS20 connection with `mac_mode: "random"` - verify MAC changes each connection
- [ ] Test HS20 connection with `mac_mode: "persistent-random"` - verify MAC persists across reconnects
- [ ] Test HS20 connection with `mac_mode: "specific"` and custom MAC address
- [ ] Verify `clearHs20Credentials` removes global MAC settings from config
- [ ] Verify regular `wifi_connect` still works after clearing HS20 credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches WiFi connectivity by writing global `wpa_supplicant.conf` settings and restarting the daemon, so misconfiguration could impact subsequent connections or privacy behavior.
> 
> **Overview**
> Adds **MAC address randomization support for HS20/Passpoint connections** by introducing global wpa_supplicant MAC config mapping (`macModeToGlobalWpaValue`) and writing/removing global settings (`mac_addr`, `preassoc_mac_addr`, `rand_addr_lifetime`, `gas_rand_mac_addr`, optional `mac_value`) via new `WpaConfig.setGlobalMacConfig`/`resetGlobalMacConfig`.
> 
> Extends `wifi_hs20_connect` with optional `mac_mode`, `mac_address`, `preassoc_mac_mode`, and `rand_addr_lifetime` parameters, applies the MAC config before daemon restart, passes the mode into DHCP startup, and ensures `clearHs20Credentials` also clears any global MAC settings to avoid affecting non-HS20 connections.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 62f4ab382ff26ee3f2039055ee4ccaff995f96fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->