### PR TITLE
Fix DNS configuration on DHCP timeout

### DIFF
--- a/src/tools/wifi.ts
+++ b/src/tools/wifi.ts
@@ -180,9 +180,14 @@ export function registerWifiTools(
           await dhcpManager.start(targetIface, macConfig?.mode);
           const ipAddress = await dhcpManager.waitForIp(10000);
 
-          // If DHCP timeout but IP exists now, still configure DNS
-          if (!ipAddress && status.ipAddress) {
-            await dhcpManager.configureDns();
+          // If DHCP timeout, re-check current status for late-arriving IP
+          let finalIpAddress = ipAddress;
+          if (!ipAddress) {
+            const currentStatus = await wpa.status();
+            if (currentStatus.ipAddress) {
+              finalIpAddress = currentStatus.ipAddress;
+              await dhcpManager.configureDns();
+            }
           }
 
           return {
@@ -193,7 +198,7 @@ export function registerWifiTools(
                   {
                     success: true,
                     message: `Connected to ${ssid}`,
-                    status: { ...status, ipAddress: ipAddress || status.ipAddress },
+                    status: { ...status, ipAddress: finalIpAddress || status.ipAddress },
                     dhcp: ipAddress ? "obtained" : "timeout",
                   },
                   null,
@@ -352,9 +357,14 @@ export function registerWifiTools(
           await dhcpManager.start(targetIface, macConfig?.mode);
           const ipAddress = await dhcpManager.waitForIp(10000);
 
-          // If DHCP timeout but IP exists now, still configure DNS
-          if (!ipAddress && status.ipAddress) {
-            await dhcpManager.configureDns();
+          // If DHCP timeout, re-check current status for late-arriving IP
+          let finalIpAddress = ipAddress;
+          if (!ipAddress) {
+            const currentStatus = await wpa.status();
+            if (currentStatus.ipAddress) {
+              finalIpAddress = currentStatus.ipAddress;
+              await dhcpManager.configureDns();
+            }
           }
 
           return {
@@ -365,7 +375,7 @@ export function registerWifiTools(
                   {
                     success: true,
                     message: `Connected to ${ssid} using EAP-${eap_method || "PEAP"}`,
-                    status: { ...status, ipAddress: ipAddress || status.ipAddress },
+                    status: { ...status, ipAddress: finalIpAddress || status.ipAddress },
                     dhcp: ipAddress ? "obtained" : "timeout",
                   },
                   null,
@@ -640,9 +650,14 @@ export function registerWifiTools(
           await dhcpManager.start(targetIface);
           const ipAddress = await dhcpManager.waitForIp(10000);
 
-          // If DHCP timeout but IP exists now, still configure DNS
-          if (!ipAddress && status.ipAddress) {
-            await dhcpManager.configureDns();
+          // If DHCP timeout, re-check current status for late-arriving IP
+          let finalIpAddress = ipAddress;
+          if (!ipAddress) {
+            const currentStatus = await wpa.status();
+            if (currentStatus.ipAddress) {
+              finalIpAddress = currentStatus.ipAddress;
+              await dhcpManager.configureDns();
+            }
           }
 
           return {
@@ -653,7 +668,7 @@ export function registerWifiTools(
                   {
                     success: true,
                     message: "Reconnected to WiFi",
-                    status: { ...status, ipAddress: ipAddress || status.ipAddress },
+                    status: { ...status, ipAddress: finalIpAddress || status.ipAddress },
                     dhcp: ipAddress ? "obtained" : "timeout",
                   },
                   null,
@@ -930,9 +945,14 @@ export function registerWifiTools(
           await dhcpManager.start(targetIface, macConfig?.mode);
           const ipAddress = await dhcpManager.waitForIp(10000);
 
-          // If DHCP timeout but IP exists now, still configure DNS
-          if (!ipAddress && status.ipAddress) {
-            await dhcpManager.configureDns();
+          // If DHCP timeout, re-check current status for late-arriving IP
+          let finalIpAddress = ipAddress;
+          if (!ipAddress) {
+            const currentStatus = await wpa.status();
+            if (currentStatus.ipAddress) {
+              finalIpAddress = currentStatus.ipAddress;
+              await dhcpManager.configureDns();
+            }
           }
 
           return {
@@ -944,7 +964,7 @@ export function registerWifiTools(
                     success: true,
                     message: `Connected to ${ssid} using EAP-TLS`,
                     credential_id: credential_id || undefined,
-                    status: { ...status, ipAddress: ipAddress || status.ipAddress },
+                    status: { ...status, ipAddress: finalIpAddress || status.ipAddress },
                     dhcp: ipAddress ? "obtained" : "timeout",
                   },
                   null,
@@ -1151,9 +1171,14 @@ export function registerWifiTools(
           await dhcpManager.start(targetIface, mac_mode as MacAddressMode | undefined);
           const ipAddress = await dhcpManager.waitForIp(10000);
 
-          // If DHCP timeout but IP exists now, still configure DNS
-          if (!ipAddress && status.ipAddress) {
-            await dhcpManager.configureDns();
+          // If DHCP timeout, re-check current status for late-arriving IP
+          let finalIpAddress = ipAddress;
+          if (!ipAddress) {
+            const currentStatus = await wpa.status();
+            if (currentStatus.ipAddress) {
+              finalIpAddress = currentStatus.ipAddress;
+              await dhcpManager.configureDns();
+            }
           }
 
           return {
@@ -1168,7 +1193,7 @@ export function registerWifiTools(
                     realm: realm,
                     domain: domain,
                     mac_mode: mac_mode || undefined,
-                    status: { ...status, ipAddress: ipAddress || status.ipAddress },
+                    status: { ...status, ipAddress: finalIpAddress || status.ipAddress },
                     dhcp: ipAddress ? "obtained" : "timeout",
                   },
                   null,

--- a/src/tools/wifi.ts
+++ b/src/tools/wifi.ts
@@ -180,6 +180,11 @@ export function registerWifiTools(
           await dhcpManager.start(targetIface, macConfig?.mode);
           const ipAddress = await dhcpManager.waitForIp(10000);
 
+          // If DHCP timeout but IP exists now, still configure DNS
+          if (!ipAddress && status.ipAddress) {
+            await dhcpManager.configureDns();
+          }
+
           return {
             content: [
               {
@@ -188,7 +193,7 @@ export function registerWifiTools(
                   {
                     success: true,
                     message: `Connected to ${ssid}`,
-                    status: { ...status, ipAddress },
+                    status: { ...status, ipAddress: ipAddress || status.ipAddress },
                     dhcp: ipAddress ? "obtained" : "timeout",
                   },
                   null,
@@ -347,6 +352,11 @@ export function registerWifiTools(
           await dhcpManager.start(targetIface, macConfig?.mode);
           const ipAddress = await dhcpManager.waitForIp(10000);
 
+          // If DHCP timeout but IP exists now, still configure DNS
+          if (!ipAddress && status.ipAddress) {
+            await dhcpManager.configureDns();
+          }
+
           return {
             content: [
               {
@@ -355,7 +365,7 @@ export function registerWifiTools(
                   {
                     success: true,
                     message: `Connected to ${ssid} using EAP-${eap_method || "PEAP"}`,
-                    status: { ...status, ipAddress },
+                    status: { ...status, ipAddress: ipAddress || status.ipAddress },
                     dhcp: ipAddress ? "obtained" : "timeout",
                   },
                   null,
@@ -630,6 +640,11 @@ export function registerWifiTools(
           await dhcpManager.start(targetIface);
           const ipAddress = await dhcpManager.waitForIp(10000);
 
+          // If DHCP timeout but IP exists now, still configure DNS
+          if (!ipAddress && status.ipAddress) {
+            await dhcpManager.configureDns();
+          }
+
           return {
             content: [
               {
@@ -638,7 +653,7 @@ export function registerWifiTools(
                   {
                     success: true,
                     message: "Reconnected to WiFi",
-                    status: { ...status, ipAddress },
+                    status: { ...status, ipAddress: ipAddress || status.ipAddress },
                     dhcp: ipAddress ? "obtained" : "timeout",
                   },
                   null,
@@ -915,6 +930,11 @@ export function registerWifiTools(
           await dhcpManager.start(targetIface, macConfig?.mode);
           const ipAddress = await dhcpManager.waitForIp(10000);
 
+          // If DHCP timeout but IP exists now, still configure DNS
+          if (!ipAddress && status.ipAddress) {
+            await dhcpManager.configureDns();
+          }
+
           return {
             content: [
               {
@@ -924,7 +944,7 @@ export function registerWifiTools(
                     success: true,
                     message: `Connected to ${ssid} using EAP-TLS`,
                     credential_id: credential_id || undefined,
-                    status: { ...status, ipAddress },
+                    status: { ...status, ipAddress: ipAddress || status.ipAddress },
                     dhcp: ipAddress ? "obtained" : "timeout",
                   },
                   null,
@@ -1131,6 +1151,11 @@ export function registerWifiTools(
           await dhcpManager.start(targetIface, mac_mode as MacAddressMode | undefined);
           const ipAddress = await dhcpManager.waitForIp(10000);
 
+          // If DHCP timeout but IP exists now, still configure DNS
+          if (!ipAddress && status.ipAddress) {
+            await dhcpManager.configureDns();
+          }
+
           return {
             content: [
               {
@@ -1143,7 +1168,7 @@ export function registerWifiTools(
                     realm: realm,
                     domain: domain,
                     mac_mode: mac_mode || undefined,
-                    status: { ...status, ipAddress },
+                    status: { ...status, ipAddress: ipAddress || status.ipAddress },
                     dhcp: ipAddress ? "obtained" : "timeout",
                   },
                   null,


### PR DESCRIPTION
## Summary

- Add fallback DNS configuration when `waitForIp()` times out but IP exists in status
- On systemd-resolved systems, DNS was left unconfigured when DHCP was slow (>10s)
- Now checks if IP arrived via wpa_supplicant status and configures DNS accordingly

## Problem

When `waitForIp()` times out, `configureDns()` was never called even if dhclient obtained an IP address after the timeout. This left DNS unconfigured on systemd-resolved systems.

## Solution

After `waitForIp()` returns, check if:
1. `ipAddress` is null (timeout)
2. `status.ipAddress` exists (IP arrived)

If both conditions met, call `configureDns()` to ensure DNS works.

## Affected handlers

- `wifi_connect`
- `wifi_connect_eap`
- `wifi_reconnect`
- `wifi_connect_tls`
- `wifi_hs20_connect`

## Test plan

- [ ] Connect to WiFi where DHCP responds quickly - verify normal path works
- [ ] Verify `resolvectl status` shows DNS configured after connection
- [ ] (Manual) Simulate slow DHCP to trigger fallback path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to WiFi connection result handling and DNS configuration on a timeout path; minimal risk aside from potential extra `configureDns()` calls during edge-case timing.
> 
> **Overview**
> Improves WiFi connection handlers to handle *slow DHCP* cases: when `DhcpManager.waitForIp()` times out but `wpa.status()` already shows an IP, the tools now treat that as the final IP and explicitly call `dhcpManager.configureDns()`.
> 
> Applies the same fallback behavior across `wifi_connect`, `wifi_connect_eap`, `wifi_reconnect`, `wifi_connect_tls`, and `wifi_hs20_connect`, and returns `status.ipAddress` populated from either DHCP or the late-arriving WPA status.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e730bea07cd75414bf1112e76cb2a28e61ebb18. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->