### PR TITLE
Improve Dockerfile: entrypoint, multi-stage build, sudoers, healthcheck

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,7 +4,10 @@ dist/
 .git/
 docs/
 tests/
-scripts/
+# Keep scripts/docker-entrypoint.sh available to COPY
+scripts/docker-run.sh
+scripts/example-portal.js
+scripts/gen-tls-call.sh
 *.log
 *.pid
 coverage/

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     sudo \
   && rm -rf /var/lib/apt/lists/*
 
-# Allow node user to run privileged commands without password
-RUN echo 'node ALL=(ALL) NOPASSWD: ALL' \
+# Allow node user to run only the specific privileged commands needed
+# for WiFi control, DHCP, and network configuration
+RUN printf 'node ALL=(ALL) NOPASSWD: \\\n\
+  /usr/sbin/wpa_supplicant, \\\n\
+  /usr/sbin/wpa_cli, \\\n\
+  /usr/sbin/dhclient, \\\n\
+  /usr/sbin/ip, \\\n\
+  /usr/bin/pkill, \\\n\
+  /usr/bin/pgrep, \\\n\
+  /usr/bin/mv, \\\n\
+  /usr/bin/chmod, \\\n\
+  /usr/bin/cat, \\\n\
+  /usr/bin/kill\n' \
   > /etc/sudoers.d/node && chmod 0440 /etc/sudoers.d/node
 
 # Create wpa_supplicant config directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,10 @@ RUN npm run build
 # Remove devDependencies after build
 RUN npm prune --omit=dev
 
+# Copy entrypoint script
+COPY scripts/docker-entrypoint.sh ./scripts/
+RUN chmod +x ./scripts/docker-entrypoint.sh
+
 # Default environment
 ENV WIFI_INTERFACE=wlan0
 ENV WPA_CONFIG_PATH=/etc/wpa_supplicant/wpa_supplicant.conf
@@ -51,4 +55,4 @@ EXPOSE 3000
 
 USER node
 
-CMD ["node", "dist/index.js"]
+ENTRYPOINT ["./scripts/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,6 +73,10 @@ ENV HOST=0.0.0.0
 
 EXPOSE 3000
 
+# Health check using Node's built-in fetch (no curl needed)
+HEALTHCHECK --interval=10s --timeout=3s --start-period=5s --retries=3 \
+  CMD node -e "fetch('http://localhost:3000/health').then(r=>{if(!r.ok)throw r.status}).catch(()=>process.exit(1))"
+
 USER node
 
 ENTRYPOINT ["./scripts/docker-entrypoint.sh"]

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# docker-entrypoint.sh -- Entrypoint for wpa-mcp Docker container
+#
+# Prepares the container's network namespace for WiFi isolation:
+# 1. Deletes the Docker bridge default route so dhclient can add WiFi
+#    as the sole default when a connection is established
+# 2. Brings up the WiFi interface if it's already present
+# 3. Execs the Node.js server
+#
+# The bridge subnet route (172.17.0.0/16 dev eth0) is preserved so the
+# MCP client can reach the server via Docker port forwarding.
+#
+# Environment:
+#   WIFI_INTERFACE       WiFi interface name (default: wlan0)
+#   KEEP_BRIDGE_DEFAULT  Set to "1" to skip bridge default route deletion
+#
+set -euo pipefail
+
+IFACE="${WIFI_INTERFACE:-wlan0}"
+
+# Delete Docker bridge default route so WiFi becomes the sole default
+# when dhclient runs during wifi_connect. The bridge subnet route is
+# preserved for MCP client access via Docker port forwarding.
+if [[ "${KEEP_BRIDGE_DEFAULT:-}" != "1" ]]; then
+  if ip route show default 2>/dev/null | grep -q "dev eth0"; then
+    echo "entrypoint: deleting bridge default route"
+    sudo ip route del default 2>/dev/null || true
+  fi
+fi
+
+# Bring WiFi interface up if present (phy may be moved in after start)
+if ip link show "$IFACE" &>/dev/null; then
+  echo "entrypoint: bringing $IFACE up"
+  sudo ip link set "$IFACE" up 2>/dev/null || true
+fi
+
+# Hand off to Node.js server
+exec node dist/index.js "$@"

--- a/scripts/docker-run.sh
+++ b/scripts/docker-run.sh
@@ -117,9 +117,9 @@ if [[ "$CONTAINER_IFACE" != "$IFACE" ]]; then
   echo "You may need to set WIFI_INTERFACE=$CONTAINER_IFACE"
 fi
 
-# --- Remove Docker bridge default route ---
-# WiFi's dhclient will add the only default route when it connects.
-# Must wait until container is fully initialized before deleting.
+# --- Wait for server to be ready ---
+# The entrypoint script deletes the Docker bridge default route on
+# startup so dhclient adds WiFi as the sole default when it connects.
 
 echo "Waiting for server to start..."
 for i in $(seq 1 30); do
@@ -128,9 +128,6 @@ for i in $(seq 1 30); do
   fi
   sleep 1
 done
-
-echo "Removing Docker bridge default route from container..."
-docker exec "$CONTAINER_NAME" sudo ip route del default 2>/dev/null || true
 
 # --- Verify ---
 

--- a/tests/integration/test-docker-netns.sh
+++ b/tests/integration/test-docker-netns.sh
@@ -278,6 +278,8 @@ if [[ "$CONTAINER_IFACE" != "$IFACE" ]]; then
 fi
 
 # Give the server time to start (wpa_supplicant starts on first request)
+# The entrypoint script deletes the Docker bridge default route on startup
+# so dhclient adds WiFi as the sole default when it connects.
 log "Waiting for wpa-mcp server..."
 if ! wait_for_health; then
   fail "Server health check did not pass within 30s"
@@ -286,11 +288,6 @@ if ! wait_for_health; then
   exit 1
 fi
 pass "Server health check passed"
-
-# Remove Docker bridge default route so WiFi becomes the only default.
-# Must happen after server is ready (Docker may restore routes during init).
-log "Removing Docker bridge default route from container..."
-docker exec "$CONTAINER_NAME" sudo ip route del default 2>/dev/null || true
 
 # ======================================================================
 # PHASE 2: Verify isolation (pre-connect)


### PR DESCRIPTION
## Summary

- Add `scripts/docker-entrypoint.sh` that automatically deletes the Docker bridge default route on startup, eliminating the manual `docker exec ip route del default` step from docker-run.sh and the integration test
- Rewrite Dockerfile as a multi-stage build (builder + runtime) to keep devDependencies out of the final image and reduce image size
- Tighten sudoers from `NOPASSWD: ALL` to an explicit allowlist of 10 commands needed for WiFi control (paths verified inside the Debian container with `visudo -c`)
- Add HEALTHCHECK instruction using Node's built-in `fetch()` (no curl dependency needed)
- Update .dockerignore to allow entrypoint script while excluding other helper scripts

## Test plan

- [x] Image builds successfully with multi-stage build
- [x] Sudoers syntax validated with `visudo -c`
- [x] Allowed sudo commands work as node user (`sudo ip route show`, `sudo cat`)
- [x] Non-allowed commands are properly denied (`sudo apt-get` blocked)
- [x] HEALTHCHECK configuration verified in image inspect
- [ ] Integration test still passes with entrypoint handling route deletion (requires WiFi hardware)


Made with [Cursor](https://cursor.com)