### PR TITLE
Add host preparation automation and Docker troubleshooting guide

### DIFF
--- a/docs/20_Troubleshooting.md
+++ b/docs/20_Troubleshooting.md
@@ -1,109 +1,152 @@
-# Problem Report: DNS Resolution Fails After WiFi Connection
+# Troubleshooting
 
-**Date:** 2026-02-01
-**Severity:** High
-**Status:** Workaround Available
+**Updated:** 2026-02-06
 
 ---
 
-## Problem Summary
+## Docker / Container Issues
 
-After connecting to a WiFi network using wpa-mcp, DNS resolution fails. Applications (Firefox, curl) cannot resolve domain names even though IP connectivity works.
+### `ip link set netns` returns "The interface netns is immutable"
 
----
+Many WiFi drivers (notably **iwlwifi** for Intel adapters) block moving the
+network interface directly into another namespace.
 
-## Environment
+**Fix:** Move the phy device instead of the interface:
 
-- **OS:** Fedora (systemd-resolved manages DNS)
-- **WiFi Interface:** wlp7s0
-- **DNS Manager:** systemd-resolved
-- **DHCP Client:** dhclient (invoked by wpa-mcp)
+```bash
+# Find the phy name
+cat /sys/class/net/wlp6s0/phy80211/name
+# e.g. phy0
 
----
+# Move the phy (interface follows automatically)
+sudo iw phy phy0 set netns $CONTAINER_PID
+```
 
-## Symptoms
-
-1. WiFi connects successfully via wpa_supplicant
-2. DHCP assigns IP address via dhclient
-3. `ping 8.8.8.8` works (IP connectivity OK)
-4. `ping google.com` fails (DNS fails)
-5. Firefox cannot load captive portal pages
-6. `/etc/resolv.conf` shows correct DNS but resolution still fails
+This works because `iw phy set netns` operates at the wireless subsystem level,
+bypassing the network interface layer restriction.
 
 ---
 
-## Root Cause Analysis
+### NetworkManager re-manages interface after container stop
 
-### Finding 1: systemd-resolved ignores /etc/resolv.conf
+When the container stops, the phy returns to the host. NetworkManager sees a
+"new" unmanaged interface and re-manages it, which can interfere with future
+container starts.
 
-On systems using systemd-resolved, `/etc/resolv.conf` is a symlink to the stub resolver. The actual DNS configuration is managed per-interface by systemd-resolved.
+**Temporary fix:**
 
-### Finding 2: dhclient does not update systemd-resolved
+```bash
+sudo nmcli device set wlp6s0 managed no
+```
 
-When wpa-mcp runs `dhclient wlp7s0`, the DHCP response includes DNS servers, but dhclient does not pass this information to systemd-resolved.
+**Persistent fix:**
 
-### Finding 3: Interface has no DNS scope
+```bash
+sudo make nm-unmanage WIFI_INTERFACE=wlp6s0
+```
+
+This creates `/etc/NetworkManager/conf.d/99-unmanaged-wlp6s0.conf` which
+survives reboots and interface reappearance. To undo:
+
+```bash
+sudo make nm-restore WIFI_INTERFACE=wlp6s0
+```
+
+---
+
+### dhclient does not add WiFi default route
+
+After WiFi connect inside the container, `ip route` shows the WiFi subnet
+route but no default route. This happens when the Docker bridge default route
+still exists — dhclient sees an existing default and only adds a subnet route.
+
+**Fix:** The Docker entrypoint script (`scripts/docker-entrypoint.sh`) deletes
+the bridge default route on startup automatically. If you're running the
+container without the entrypoint, manually delete it before connecting:
+
+```bash
+docker exec wpa-mcp sudo ip route del default
+```
+
+---
+
+### wpa_cli returns "Failed to connect to non-global ctrl_ifname"
+
+Inside the container, wpa_cli cannot find the control socket.
+
+**Cause:** The wpa_supplicant.conf must include `GROUP=node` (or the group the
+node user belongs to) in the `ctrl_interface` directive:
+
+```
+ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=node
+```
+
+The Dockerfile sets this automatically. If you override the config, ensure the
+GROUP is correct.
+
+---
+
+### Host wpa_supplicant conflicts with container
+
+If a wpa_supplicant process on the host is bound to the same interface (`-i wlp6s0`),
+it will conflict with the container's wpa_supplicant after the phy is moved.
+
+**Fix:** Stop the host wpa_supplicant before starting the container:
+
+```bash
+sudo pkill -f 'wpa_supplicant.*-i.*wlp6s0'
+# Or if managed by systemd:
+sudo systemctl stop wpa_supplicant
+```
+
+The `docker-run.sh` script checks for this automatically and exits with an
+error if a conflict is detected.
+
+---
+
+## DNS Issues
+
+### DNS resolution fails after WiFi connection (systemd-resolved)
+
+**Date:** 2026-02-01 | **Severity:** High | **Status:** Workaround Available
+
+After connecting to WiFi, DNS resolution fails. `ping 8.8.8.8` works but
+`ping google.com` does not.
+
+**Environment:** Fedora with systemd-resolved, running wpa-mcp directly on host
+(not in Docker container).
+
+**Root cause:** dhclient obtains DNS servers from DHCP but does not notify
+systemd-resolved. The WiFi interface has no DNS scope:
 
 ```bash
 $ resolvectl status wlp7s0
-
 Link 4 (wlp7s0)
-    Current Scopes: LLMNR/IPv4 LLMNR/IPv6    # <-- No "DNS" scope
-         Protocols: -DefaultRoute             # <-- Not default route for DNS
+    Current Scopes: LLMNR/IPv4 LLMNR/IPv6    # No "DNS" scope
+         Protocols: -DefaultRoute             # Not default route for DNS
 ```
 
-The WiFi interface was not configured as a DNS source, so systemd-resolved never used it for resolution.
-
----
-
-## Solution
-
-Manually configure DNS for the interface using `resolvectl`:
+**Fix:** Manually configure DNS for the interface:
 
 ```bash
 sudo resolvectl dns wlp7s0 192.168.3.1
 ```
 
-### Verification
+**Verification:**
 
 ```bash
 $ resolvectl status wlp7s0
-
 Link 4 (wlp7s0)
-    Current Scopes: DNS LLMNR/IPv4 LLMNR/IPv6    # <-- Now includes "DNS"
-         Protocols: +DefaultRoute                 # <-- Now default route
-       DNS Servers: 192.168.3.1                   # <-- DNS configured
+    Current Scopes: DNS LLMNR/IPv4 LLMNR/IPv6
+         Protocols: +DefaultRoute
+       DNS Servers: 192.168.3.1
 ```
 
-DNS resolution now works.
+**Note:** This fix is not persistent across disconnect/reconnect. wpa-mcp
+includes automatic DNS fallback configuration — if DHCP times out or does not
+configure DNS, it runs `resolvectl` with the gateway IP.
 
----
-
-## Limitation
-
-This fix is **not persistent**. The `resolvectl dns` setting is lost on:
-- WiFi disconnect/reconnect
-- Reboot
-- Interface restart
-
----
-
-## Recommended Fix
-
-Modify wpa-mcp to run `resolvectl` after `dhclient` completes:
-
-```bash
-dhclient wlp7s0 && resolvectl dns wlp7s0 <gateway_ip>
-```
-
-The gateway IP can be extracted from:
-- DHCP response
-- `ip route show default`
-
----
-
-## Related
-
-- dhclient exit hooks (`/etc/dhcp/dhclient-exit-hooks.d/`) do not work when dhclient is invoked directly by wpa-mcp
-- NetworkManager handles this automatically but is excluded to allow wpa_supplicant control
-- Firefox may also need DoH disabled (`network.trr.mode = 5`) to use system DNS
+**Related:**
+- dhclient exit hooks don't work when dhclient is invoked directly by wpa-mcp
+- NetworkManager handles this automatically but is excluded for wpa_supplicant control
+- Firefox may need DoH disabled (`network.trr.mode = 5`) to use system DNS

--- a/scripts/docker-run.sh
+++ b/scripts/docker-run.sh
@@ -49,6 +49,16 @@ if ! command -v iw &>/dev/null; then
   exit 1
 fi
 
+# --- Check for host wpa_supplicant binding this interface ---
+
+if pgrep -a wpa_supplicant 2>/dev/null | grep -q -- "-i[[:space:]]*${IFACE}"; then
+  echo "Warning: host wpa_supplicant is bound to $IFACE"
+  echo "  This will conflict with the container's wpa_supplicant."
+  echo "  Stop it first:  sudo pkill -f 'wpa_supplicant.*-i.*${IFACE}'"
+  echo "  Or if managed by systemd:  sudo systemctl stop wpa_supplicant"
+  exit 1
+fi
+
 # --- Resolve phy device from interface ---
 
 PHY=$(cat "/sys/class/net/${IFACE}/phy80211/name" 2>/dev/null || true)


### PR DESCRIPTION
## Summary

- Add `make nm-unmanage` and `make nm-restore` targets for persistent NetworkManager unmanage via drop-in config file (survives reboots and interface reappearance)
- Add wpa_supplicant preflight check in docker-run.sh that detects and blocks conflicting host wpa_supplicant processes before container start
- Restructure `docs/20_Troubleshooting.md` into a general troubleshooting guide with Docker-specific entries covering common issues: netns immutable error, NM re-management, missing default route, control socket permissions, host wpa_supplicant conflicts

## Test plan

- [x] Makefile nm-unmanage/nm-restore targets have root check and NM availability check
- [x] docker-run.sh preflight check pattern matches wpa_supplicant bound to specific interface
- [x] Troubleshooting doc covers all issues identified during integration testing


Made with [Cursor](https://cursor.com)