### PR TITLE
Add Docker documentation and update development plan

### DIFF
--- a/docs/30_Docker_Dev_Plan.md
+++ b/docs/30_Docker_Dev_Plan.md
@@ -1,6 +1,6 @@
 # Docker Development Plan
 
-**Status:** Draft  
+**Status:** Active  
 **Updated:** 2026-02-06
 
 ---
@@ -25,11 +25,11 @@ covers remaining work to make it production-ready and improve the developer expe
 
 ## Phase 1: Push current branch and merge
 
-**Branch:** `feature/docker-netns-docs`
+**Branch:** `feature/docker-netns-docs` | **PR:** #15 | **Merged**
 
-- [ ] Push branch to origin
-- [ ] Create PR with 5 commits
-- [ ] Review and merge to main
+- [x] Push branch to origin
+- [x] Create PR with 6 commits
+- [x] Review and merge to main
 
 ---
 
@@ -44,9 +44,9 @@ Currently the test script runs `nmcli device set <iface> managed no` which
 is temporary -- NM re-manages the device when it reappears after container
 stops.
 
-- [ ] Add persistent unmanage option: create `/etc/NetworkManager/conf.d/99-unmanaged-<iface>.conf`
-- [ ] Add `make nm-unmanage WIFI_INTERFACE=wlp6s0` target
-- [ ] Add `make nm-restore WIFI_INTERFACE=wlp6s0` to undo
+- [x] Add persistent unmanage option: create `/etc/NetworkManager/conf.d/99-unmanaged-<iface>.conf`
+- [x] Add `make nm-unmanage WIFI_INTERFACE=wlp6s0` target
+- [x] Add `make nm-restore WIFI_INTERFACE=wlp6s0` to undo
 
 ### 2.2 Host wpa_supplicant conflict
 
@@ -55,8 +55,8 @@ This doesn't interfere with the container's wpa_supplicant (different netns),
 but should be documented. If someone runs wpa_supplicant with `-i <iface>` on
 the host, the container's instance will conflict.
 
-- [ ] Add preflight check in docker-run.sh: warn if host wpa_supplicant binds the same interface
-- [ ] Document in troubleshooting
+- [x] Add preflight check in docker-run.sh: warn if host wpa_supplicant binds the same interface
+- [x] Document in troubleshooting
 
 ---
 
@@ -68,15 +68,10 @@ Currently dhclient only adds a WiFi default route if the bridge default is
 deleted first. This is a manual step (`docker exec ... ip route del default`).
 
 Options to automate:
-- [ ] **Option A**: Entrypoint script that deletes bridge default on startup,
-      then starts Node. Requires a custom entrypoint.
-- [ ] **Option B**: Add a startup hook in `src/index.ts` that deletes the
-      non-WiFi default route before first WiFi connect.
-- [ ] **Option C**: Keep it in docker-run.sh (current approach). Simplest,
-      but requires the helper script.
-
-**Recommendation:** Option A (entrypoint script). It keeps the logic in the
-container image and works regardless of how the container is started.
+- [x] **Option A**: Entrypoint script that deletes bridge default on startup,
+      then starts Node. Requires a custom entrypoint. **Implemented in PR #16.**
+- [ ] ~~**Option B**: Add a startup hook in `src/index.ts`~~ (not needed)
+- [ ] ~~**Option C**: Keep it in docker-run.sh~~ (superseded by Option A)
 
 ### 3.2 DNS inside the container
 
@@ -95,35 +90,29 @@ doesn't go through the WiFi network. For true isolation:
 
 ### 4.1 Multi-stage build
 
-Current Dockerfile installs all npm deps (including devDependencies), builds,
-then prunes. A multi-stage build would be cleaner:
-
-- [ ] Stage 1: `node:22` — install all deps, build TypeScript
-- [ ] Stage 2: `node:22-slim` — copy dist/ and production node_modules only
-- [ ] Reduces final image size
+- [x] Stage 1: `node:22` — install all deps, build TypeScript
+- [x] Stage 2: `node:22-slim` — copy dist/ and production node_modules only
+- [x] Reduces final image size
 
 ### 4.2 Entrypoint script
 
-- [ ] Create `scripts/docker-entrypoint.sh`:
+- [x] Create `scripts/docker-entrypoint.sh`:
   1. Delete bridge default route (if WiFi interface present)
   2. Bring WiFi interface up (if present in netns)
   3. Exec `node dist/index.js`
-- [ ] Update Dockerfile: `ENTRYPOINT ["./scripts/docker-entrypoint.sh"]`
+- [x] Update Dockerfile: `ENTRYPOINT ["./scripts/docker-entrypoint.sh"]`
 
 ### 4.3 Sudoers tightening
 
-Current Dockerfile uses `NOPASSWD: ALL` for simplicity. Tighten to specific
-commands:
-
-- [ ] Enumerate exact paths inside Debian: `wpa_supplicant`, `wpa_cli`,
+- [x] Enumerate exact paths inside Debian: `wpa_supplicant`, `wpa_cli`,
       `dhclient`, `ip`, `pkill`, `pgrep`, `mv`, `chmod`, `cat`, `kill`
-- [ ] Verify paths with `which` inside the container
-- [ ] Replace `ALL` with explicit list
+- [x] Verify paths with `which` inside the container
+- [x] Replace `ALL` with explicit list
 
 ### 4.4 Health check
 
-- [ ] Add `HEALTHCHECK` instruction to Dockerfile:
-      `HEALTHCHECK --interval=5s --timeout=3s CMD curl -sf http://localhost:3000/health`
+- [x] Add `HEALTHCHECK` instruction to Dockerfile using Node built-in `fetch()`
+      (no curl dependency needed)
 
 ---
 
@@ -155,13 +144,14 @@ The current test requires real WiFi hardware and sudo. For CI:
 
 ## Phase 6: Documentation
 
-- [ ] Add Docker section to main README.md
-- [ ] Add troubleshooting entries to `docs/20_Troubleshooting.md`:
+- [x] Add Docker section to main README.md
+- [x] Add troubleshooting entries to `docs/20_Troubleshooting.md`:
   - `ip link set netns` immutable error → use `iw phy`
   - NM re-manages interface after container stop
   - dhclient doesn't add default route (bridge default exists)
   - wpa_cli permission denied (GROUP= in wpa_supplicant.conf)
-- [ ] Update `docs/README.md` feature table with Docker support
+  - Host wpa_supplicant conflict
+- [x] Update `docs/README.md` feature table with Docker support
 
 ---
 
@@ -192,10 +182,10 @@ document differences:
 
 ## Priority order
 
-1. **Phase 1** — Merge current branch (ready now)
-2. **Phase 4.2** — Entrypoint script (eliminates manual bridge default delete)
-3. **Phase 4.3** — Tighten sudoers
-4. **Phase 2.1** — Persistent NM unmanage
+1. ~~**Phase 1** — Merge current branch~~ (done: PR #15)
+2. ~~**Phase 4.2** — Entrypoint script~~ (done: PR #16)
+3. ~~**Phase 4.3** — Tighten sudoers~~ (done: PR #16)
+4. ~~**Phase 2.1** — Persistent NM unmanage~~ (done: PR #17)
 5. **Phase 5.1** — CI-friendly test
-6. **Phase 6** — Documentation updates
+6. ~~**Phase 6** — Documentation updates~~ (done: PR #18)
 7. Everything else as needed

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,8 @@
 # wpa-mcp Documentation
 
 **Status:** Complete  
-**Version:** 1.0.0  
-**Updated:** 2026-01-14
+**Version:** 1.1.0  
+**Updated:** 2026-02-06
 
 ---
 
@@ -151,6 +151,11 @@ This documentation provides a comprehensive reference for the wpa-mcp project - 
 | **Privacy** | | | |
 | | MAC Randomization | Per-connection MAC address control | Complete |
 | | Pre-assoc MAC | MAC randomization during scanning | Complete |
+| **Docker** | | | |
+| | Network Namespace Isolation | WiFi phy moved into container netns | Complete |
+| | Entrypoint Route Cleanup | Automatic bridge default route deletion | Complete |
+| | NM Unmanage Automation | Persistent NetworkManager unmanage via Makefile | Complete |
+| | Integration Test | Full lifecycle test (18/18 pass) | Complete |
 
 ---
 
@@ -172,6 +177,13 @@ This documentation provides a comprehensive reference for the wpa-mcp project - 
 |---|----------|-------------|
 | 10 | [EAP-TLS Authentication](./10_EAP-TLS_Design.md) | 802.1X certificate authentication design |
 | 11 | [Credential Store](./11_Credential_Store_Design.md) | Certificate storage system design |
+| 30 | [Docker Dev Plan](./30_Docker_Dev_Plan.md) | Docker production-readiness roadmap |
+
+### Operations
+
+| # | Document | Description |
+|---|----------|-------------|
+| 20 | [Troubleshooting](./20_Troubleshooting.md) | Docker and DNS troubleshooting guide |
 
 ---
 


### PR DESCRIPTION
## Summary

- Add Docker section to main README.md with quick start guide, architecture overview, and Makefile commands for Docker workflows
- Update docs/README.md feature table with Docker capabilities (netns isolation, entrypoint route cleanup, NM unmanage automation, integration test)
- Add Docker dev plan and troubleshooting guide to the document index
- Update docs/30_Docker_Dev_Plan.md to check off all completed phases (1, 2, 3.1, 4, 6) with PR references

## Test plan

- [x] README Docker quick start commands are accurate
- [x] docs/README.md feature table rows match implemented features
- [x] Document index links resolve to existing files
- [x] Dev plan checkboxes match merged PRs (#15, #16, #17)


Made with [Cursor](https://cursor.com)