### PR TITLE
Add auto-import of certificates into Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -60,9 +60,14 @@ COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package.json ./
 
-# Copy entrypoint script
+# Copy entrypoint and cert import scripts
 COPY docker/entrypoint.sh ./scripts/docker-entrypoint.sh
+COPY docker/import-certs.mjs ./scripts/import-certs.mjs
 RUN chmod +x ./scripts/docker-entrypoint.sh
+
+# Copy certificate files for auto-import at startup
+# Owned by node so credential store can read them without permission issues
+COPY --chown=node:node certs/ /app/certs/
 
 # Default environment
 ENV WIFI_INTERFACE=wlan0

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -35,5 +35,11 @@ if ip link show "$IFACE" &>/dev/null; then
   sudo ip link set "$IFACE" up 2>/dev/null || true
 fi
 
+# Auto-import certificates into credential store on first boot
+if [ -d /app/certs ] && [ "$(ls -A /app/certs 2>/dev/null)" ]; then
+  echo "entrypoint: importing certificates..."
+  node /app/scripts/import-certs.mjs || echo "entrypoint: cert import failed (non-fatal)"
+fi
+
 # Hand off to Node.js server
 exec node dist/index.js "$@"

--- a/docker/import-certs.mjs
+++ b/docker/import-certs.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+/**
+ * import-certs.mjs -- Auto-import certificates into credential store
+ *
+ * Scans /app/certs/ for client certificate + private key pairs and
+ * imports them into the wpa-mcp credential store. Idempotent: skips
+ * certs that are already imported.
+ *
+ * Naming convention:
+ *   <identity>_crt.pem  -- client certificate
+ *   <identity>_prv.pem  -- matching private key
+ *   radius.*_crt.pem | ca*.pem  -- CA certificate (optional, shared)
+ *
+ * Run: node /app/scripts/import-certs.mjs [CERTS_DIR]
+ */
+
+import { readdirSync, existsSync } from 'fs';
+import { join } from 'path';
+import { CredentialStore } from '../dist/lib/credential-store.js';
+
+const CERTS_DIR = process.argv[2] || '/app/certs';
+
+async function findCaCert(dir, files) {
+  // Look for CA cert: radius.*_crt.pem or ca*.pem
+  const caCert = files.find(f =>
+    (f.startsWith('radius.') && f.endsWith('_crt.pem')) ||
+    (f.startsWith('ca') && f.endsWith('.pem'))
+  );
+  return caCert ? join(dir, caCert) : undefined;
+}
+
+async function findCertPairs(dir, files) {
+  // Find *_crt.pem files that are NOT CA certs
+  const clientCerts = files.filter(f =>
+    f.endsWith('_crt.pem') &&
+    !f.startsWith('radius.') &&
+    !f.startsWith('ca')
+  );
+
+  const pairs = [];
+  for (const certFile of clientCerts) {
+    // Derive private key filename: replace _crt.pem with _prv.pem
+    const keyFile = certFile.replace('_crt.pem', '_prv.pem');
+    if (files.includes(keyFile)) {
+      pairs.push({
+        clientCert: join(dir, certFile),
+        privateKey: join(dir, keyFile),
+      });
+    } else {
+      console.warn(`import-certs: no matching key for ${certFile} (expected ${keyFile}), skipping`);
+    }
+  }
+
+  return pairs;
+}
+
+async function main() {
+  if (!existsSync(CERTS_DIR)) {
+    console.log(`import-certs: ${CERTS_DIR} not found, nothing to import`);
+    return;
+  }
+
+  const files = readdirSync(CERTS_DIR).filter(f => f.endsWith('.pem'));
+  if (files.length === 0) {
+    console.log(`import-certs: no .pem files in ${CERTS_DIR}, nothing to import`);
+    return;
+  }
+
+  console.log(`import-certs: found ${files.length} PEM file(s) in ${CERTS_DIR}`);
+
+  const store = new CredentialStore();
+  const caCertPath = await findCaCert(CERTS_DIR, files);
+  const pairs = await findCertPairs(CERTS_DIR, files);
+
+  if (pairs.length === 0) {
+    console.log('import-certs: no certificate/key pairs found');
+    return;
+  }
+
+  if (caCertPath) {
+    console.log(`import-certs: using CA cert: ${caCertPath}`);
+  }
+
+  let imported = 0;
+  let skipped = 0;
+
+  for (const pair of pairs) {
+    try {
+      const result = await store.storeFromPaths(
+        pair.clientCert,
+        pair.privateKey,
+        caCertPath
+      );
+
+      if (result.created) {
+        console.log(`import-certs: imported ${result.identity} (id: ${result.id})`);
+        imported++;
+      } else {
+        console.log(`import-certs: already exists ${result.identity} (id: ${result.id}), updated`);
+        skipped++;
+      }
+    } catch (err) {
+      console.error(`import-certs: failed to import ${pair.clientCert}: ${err.message}`);
+    }
+  }
+
+  console.log(`import-certs: done (imported: ${imported}, skipped: ${skipped})`);
+}
+
+main().catch(err => {
+  console.error(`import-certs: fatal error: ${err.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Copies `certs/` directory into the Docker image at build time with `node:node` ownership, avoiding file permission issues from `docker cp` or volume mounts
- Adds `docker/import-certs.mjs` script that scans `/app/certs/` for certificate/key pairs and imports them into the credential store using `CredentialStore.storeFromPaths()`
- Runs the import script automatically in `docker/entrypoint.sh` before starting the server (idempotent, non-fatal on failure)

## Test plan

- [ ] Run `make build` in `docker/` and verify the image builds successfully
- [ ] Start the container and check logs for `entrypoint: importing certificates...` and successful import messages
- [ ] Call `credential_list` MCP tool and verify the `user02@tsengsyu.com` credential appears
- [ ] Call `credential_get` with the returned credential ID and verify paths and metadata
- [ ] Restart the container and verify the import is idempotent (shows "already exists" on second boot)
- [ ] Test `wifi_connect_tls` using the imported credential


Made with [Cursor](https://cursor.com)