### PR TITLE
Add user stories for all MCP tools with test traceability

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -184,7 +184,11 @@ This documentation provides a comprehensive reference for the wpa-mcp project - 
 
 | # | Document | Description |
 |---|----------|-------------|
-| | *(Use `/user-stories` to generate)* | Stories with acceptance criteria and test traceability |
+| 40 | [WiFi Stories](./user-stories/40_WiFi_Stories.md) | WiFi connection, management, and diagnostics (13 stories) |
+| 41 | [Connectivity Stories](./user-stories/41_Connectivity_Stories.md) | Network diagnostics — ping, DNS, internet, captive portal (4 stories) |
+| 42 | [Browser Stories](./user-stories/42_Browser_Stories.md) | Browser automation for captive portals (3 stories) |
+| 43 | [Credential Stories](./user-stories/43_Credential_Stories.md) | EAP-TLS certificate management (4 stories) |
+| 44 | [Cross-Cutting Stories](./user-stories/44_Cross_Cutting_Stories.md) | MAC privacy, Docker isolation (3 stories) |
 
 ### Plans
 

--- a/docs/user-stories/40_WiFi_Stories.md
+++ b/docs/user-stories/40_WiFi_Stories.md
@@ -1,0 +1,399 @@
+# WiFi User Stories
+
+**Status:** Draft
+**Created:** 2026-04-10
+**Source:** [src/tools/wifi.ts](../../src/tools/wifi.ts) | [01_WiFi_Tools](../reference/01_WiFi_Tools.md)
+
+---
+
+## US-WIFI-001: Scan for Available Networks
+
+**Tool:** wifi_scan | **Ref:** [01_WiFi_Tools - wifi_scan](../reference/01_WiFi_Tools.md#wifi_scan)
+
+As a user, I want to scan for available WiFi networks so that I can see what networks are nearby and choose one to connect to.
+
+### Acceptance Criteria
+
+1. Scan returns a list of networks with SSID, BSSID, signal strength, and security flags
+2. Hidden networks (empty SSID) appear in results with BSSID
+3. Scan timeout is configurable (default 10s)
+4. Retry mode handles wpa_supplicant INACTIVE state gracefully
+5. Scan on non-existent interface returns informative error
+
+### Test Mapping
+
+| AC# | Test Case | Status |
+|-----|-----------|--------|
+| 1 | TC-INT-003 | Partial (registration only) |
+| 2 | — | No test |
+| 3 | — | No test |
+| 4 | — | No test |
+| 5 | — | No test |
+
+### Tags
+`wifi`, `scan`, `discovery`
+
+---
+
+## US-WIFI-002: Connect to WPA-PSK Network
+
+**Tool:** wifi_connect | **Ref:** [01_WiFi_Tools - wifi_connect](../reference/01_WiFi_Tools.md#wifi_connect)
+
+As a user, I want to connect to a WPA-PSK WiFi network so that the device gets online with a secured connection.
+
+### Acceptance Criteria
+
+1. Connect with SSID + password reaches COMPLETED state
+2. DHCP acquires an IP address after connection
+3. Wrong password returns WRONG_KEY error with context
+4. Connection timeout returns informative error (not hang)
+5. BSSID targeting connects to a specific access point
+
+### Test Mapping
+
+| AC# | Test Case | Status |
+|-----|-----------|--------|
+| 1 | TC-INT-003 | Partial (registration only) |
+| 2 | — | No test |
+| 3 | — | No test |
+| 4 | — | No test |
+| 5 | — | No test |
+
+### Tags
+`wifi`, `connect`, `psk`
+
+---
+
+## US-WIFI-003: Connect to Open / OWE Network
+
+**Tool:** wifi_connect | **Ref:** [01_WiFi_Tools - wifi_connect](../reference/01_WiFi_Tools.md#wifi_connect)
+
+As a user, I want to connect to an open or OWE (Enhanced Open) network so that I can access public WiFi or encrypted-open networks.
+
+### Acceptance Criteria
+
+1. Connect without password to open network reaches COMPLETED state
+2. Connect with security_type='owe' uses OWE encryption without password
+3. security_type='auto' defaults to open when no password provided
+4. DHCP acquires IP address after open network connection
+
+### Test Mapping
+
+| AC# | Test Case | Status |
+|-----|-----------|--------|
+| 1 | — | No test |
+| 2 | — | No test |
+| 3 | — | No test |
+| 4 | — | No test |
+
+### Tags
+`wifi`, `connect`, `open`, `owe`
+
+---
+
+## US-WIFI-004: Connect to WPA2-Enterprise (EAP) Network
+
+**Tool:** wifi_connect_eap | **Ref:** [01_WiFi_Tools - wifi_connect_eap](../reference/01_WiFi_Tools.md#wifi_connect_eap)
+
+As a user, I want to connect to a WPA2-Enterprise network using username and password so that I can access corporate WiFi.
+
+### Acceptance Criteria
+
+1. PEAP+MSCHAPV2 connection reaches COMPLETED state with IP
+2. TTLS+PAP connection reaches COMPLETED state with IP
+3. Wrong identity/password returns AUTH_FAILED with context
+4. EAP method and phase2 are configurable
+5. BSSID targeting works with EAP connections
+
+### Test Mapping
+
+| AC# | Test Case | Status |
+|-----|-----------|--------|
+| 1 | TC-INT-003 | Partial (registration only) |
+| 2 | — | No test |
+| 3 | — | No test |
+| 4 | — | No test |
+| 5 | — | No test |
+
+### Tags
+`wifi`, `connect`, `eap`, `enterprise`
+
+---
+
+## US-WIFI-005: Connect with EAP-TLS Certificate
+
+**Tool:** wifi_connect_tls | **Ref:** [01_WiFi_Tools - wifi_connect_tls](../reference/01_WiFi_Tools.md#wifi_connect_tls)
+
+As a user, I want to connect to a WPA2-Enterprise network using EAP-TLS certificates so that I can authenticate without transmitting passwords.
+
+### Acceptance Criteria
+
+1. Connect via credential_id loads stored certs and reaches COMPLETED state
+2. Connect via explicit file paths (identity + cert + key) reaches COMPLETED state
+3. Encrypted private key with password works
+4. Missing credential_id returns informative error
+5. Missing required params (no credential_id and no file paths) returns validation error
+6. CA certificate is optional (insecure mode for testing)
+
+### Test Mapping
+
+| AC# | Test Case | Status |
+|-----|-----------|--------|
+| 1 | TC-INT-003 | Partial (registration only) |
+| 2 | — | No test |
+| 3 | — | No test |
+| 4 | — | No test |
+| 5 | — | No test |
+| 6 | — | No test |
+
+### Tags
+`wifi`, `connect`, `eap-tls`, `certificate`
+
+---
+
+## US-WIFI-006: Connect via Hotspot 2.0 (Passpoint)
+
+**Tool:** wifi_hs20_connect | **Ref:** [01_WiFi_Tools - wifi_hs20_connect](../reference/01_WiFi_Tools.md#wifi_hs20_connect)
+
+As a user, I want to connect to a Hotspot 2.0 network so that the device auto-discovers and connects to compatible networks via ANQP.
+
+### Acceptance Criteria
+
+1. HS20 connection with valid credential_id + realm + domain reaches COMPLETED state
+2. ANQP auto-discovers matching network (no SSID needed)
+3. No matching HS20 network returns informative timeout error
+4. Invalid credential_id returns error before connection attempt
+5. Previous HS20 credentials are cleared before new connection
+6. Failed connection cleans up HS20 credential from config
+
+### Test Mapping
+
+| AC# | Test Case | Status |
+|-----|-----------|--------|
+| 1 | TC-INT-003 | Partial (registration only) |
+| 2 | — | No test |
+| 3 | — | No test |
+| 4 | — | No test |
+| 5 | — | No test |
+| 6 | — | No test |
+
+### Tags
+`wifi`, `connect`, `hs20`, `passpoint`
+
+---
+
+## US-WIFI-007: Disconnect from Network
+
+**Tool:** wifi_disconnect | **Ref:** [01_WiFi_Tools - wifi_disconnect](../reference/01_WiFi_Tools.md#wifi_disconnect)
+
+As a user, I want to disconnect from the current WiFi network so that the device stops using that connection.
+
+### Acceptance Criteria
+
+1. Disconnect releases DHCP lease and flushes IP
+2. wpa_state changes to DISCONNECTED after disconnect
+3. HS20 credentials are cleared if active
+4. Disconnect when already disconnected returns success (idempotent)
+
+### Test Mapping
+
+| AC# | Test Case | Status |
+|-----|-----------|--------|
+| 1 | — | No test |
+| 2 | — | No test |
+| 3 | — | No test |
+| 4 | — | No test |
+
+### Tags
+`wifi`, `disconnect`
+
+---
+
+## US-WIFI-008: Check Connection Status
+
+**Tool:** wifi_status | **Ref:** [01_WiFi_Tools - wifi_status](../reference/01_WiFi_Tools.md#wifi_status)
+
+As a user, I want to check the current WiFi connection status so that I know if I'm connected, to which network, and with what IP.
+
+### Acceptance Criteria
+
+1. Returns wpa_state, SSID, BSSID, IP address when connected
+2. Returns wpa_state=DISCONNECTED when not connected
+3. EAP connections include eap_state, EAP_method, identity
+4. Returns key_mgmt showing security type (WPA2-PSK, WPA-EAP, etc.)
+
+### Test Mapping
+
+| AC# | Test Case | Status |
+|-----|-----------|--------|
+| 1 | TC-INT-003 | Partial (registration only) |
+| 2 | — | No test |
+| 3 | — | No test |
+| 4 | — | No test |
+
+### Tags
+`wifi`, `status`
+
+---
+
+## US-WIFI-009: List Saved Networks
+
+**Tool:** wifi_list_networks | **Ref:** [01_WiFi_Tools - wifi_list_networks](../reference/01_WiFi_Tools.md#wifi_list_networks)
+
+As a user, I want to list saved WiFi networks so that I can see which networks are configured and their status.
+
+### Acceptance Criteria
+
+1. Returns list of saved networks with network_id, SSID, BSSID, flags
+2. CURRENT flag indicates the connected network
+3. TEMP-DISABLED flag indicates authentication failure
+4. Empty list returned when no networks configured
+
+### Test Mapping
+
+| AC# | Test Case | Status |
+|-----|-----------|--------|
+| 1 | TC-INT-003 | Partial (registration only) |
+| 2 | — | No test |
+| 3 | — | No test |
+| 4 | — | No test |
+
+### Tags
+`wifi`, `networks`, `list`
+
+---
+
+## US-WIFI-010: Forget a Saved Network
+
+**Tool:** wifi_forget | **Ref:** [01_WiFi_Tools - wifi_forget](../reference/01_WiFi_Tools.md#wifi_forget)
+
+As a user, I want to remove a saved WiFi network so that I can clear wrong credentials or unused configurations.
+
+### Acceptance Criteria
+
+1. Remove network by network_id succeeds
+2. Removed network no longer appears in wifi_list_networks
+3. Invalid network_id returns informative error
+
+### Test Mapping
+
+| AC# | Test Case | Status |
+|-----|-----------|--------|
+| 1 | — | No test |
+| 2 | — | No test |
+| 3 | — | No test |
+
+### Tags
+`wifi`, `forget`, `networks`
+
+---
+
+## US-WIFI-011: Reconnect to Saved Network
+
+**Tool:** wifi_reconnect | **Ref:** [01_WiFi_Tools - wifi_reconnect](../reference/01_WiFi_Tools.md#wifi_reconnect)
+
+As a user, I want to reconnect to the current or most recent WiFi network without re-entering credentials.
+
+### Acceptance Criteria
+
+1. Reconnect uses saved configuration (no SSID/password needed)
+2. Reaches COMPLETED state and acquires IP via DHCP
+3. Reconnect when no saved network exists returns informative error
+
+### Test Mapping
+
+| AC# | Test Case | Status |
+|-----|-----------|--------|
+| 1 | — | No test |
+| 2 | — | No test |
+| 3 | — | No test |
+
+### Tags
+`wifi`, `reconnect`
+
+---
+
+## US-WIFI-012: Get EAP Diagnostics
+
+**Tool:** wifi_eap_diagnostics | **Ref:** [01_WiFi_Tools - wifi_eap_diagnostics](../reference/01_WiFi_Tools.md#wifi_eap_diagnostics)
+
+As a user, I want to get detailed EAP authentication diagnostics so that I can troubleshoot enterprise WiFi connection failures.
+
+### Acceptance Criteria
+
+1. Returns eap_state, selectedMethod, methodState, decision
+2. eap_state=SUCCESS after successful EAP authentication
+3. eap_state=IDLE with decision=FAIL indicates server rejected credentials
+4. Works when no EAP connection is active (returns IDLE state)
+
+### Test Mapping
+
+| AC# | Test Case | Status |
+|-----|-----------|--------|
+| 1 | — | No test |
+| 2 | — | No test |
+| 3 | — | No test |
+| 4 | — | No test |
+
+### Tags
+`wifi`, `diagnostics`, `eap`
+
+---
+
+## US-WIFI-013: Get Debug Logs
+
+**Tool:** wifi_get_debug_logs | **Ref:** [01_WiFi_Tools - wifi_get_debug_logs](../reference/01_WiFi_Tools.md#wifi_get_debug_logs)
+
+As a user, I want to get filtered wpa_supplicant debug logs so that I can troubleshoot connection issues.
+
+### Acceptance Criteria
+
+1. Filter "eap" returns only EAP/802.1X related log lines
+2. Filter "state" returns connection state transitions
+3. Filter "scan" returns network discovery logs
+4. Filter "error" returns failures and timeouts
+5. since_last_command=true returns only logs since last WiFi operation
+6. Lines parameter limits output length
+
+### Test Mapping
+
+| AC# | Test Case | Status |
+|-----|-----------|--------|
+| 1 | — | No test |
+| 2 | — | No test |
+| 3 | — | No test |
+| 4 | — | No test |
+| 5 | — | No test |
+| 6 | — | No test |
+
+### Tags
+`wifi`, `diagnostics`, `logs`
+
+---
+
+## Traceability Matrix
+
+| Story | AC | Test Case | Status |
+|-------|-----|-----------|--------|
+| US-WIFI-001 | AC1 | TC-INT-003 | Partial (registration only) |
+| US-WIFI-001 | AC2-5 | — | No test |
+| US-WIFI-002 | AC1 | TC-INT-003 | Partial (registration only) |
+| US-WIFI-002 | AC2-5 | — | No test |
+| US-WIFI-003 | AC1-4 | — | No test |
+| US-WIFI-004 | AC1 | TC-INT-003 | Partial (registration only) |
+| US-WIFI-004 | AC2-5 | — | No test |
+| US-WIFI-005 | AC1 | TC-INT-003 | Partial (registration only) |
+| US-WIFI-005 | AC2-6 | — | No test |
+| US-WIFI-006 | AC1 | TC-INT-003 | Partial (registration only) |
+| US-WIFI-006 | AC2-6 | — | No test |
+| US-WIFI-007 | AC1-4 | — | No test |
+| US-WIFI-008 | AC1 | TC-INT-003 | Partial (registration only) |
+| US-WIFI-008 | AC2-4 | — | No test |
+| US-WIFI-009 | AC1 | TC-INT-003 | Partial (registration only) |
+| US-WIFI-009 | AC2-4 | — | No test |
+| US-WIFI-010 | AC1-3 | — | No test |
+| US-WIFI-011 | AC1-3 | — | No test |
+| US-WIFI-012 | AC1-4 | — | No test |
+| US-WIFI-013 | AC1-6 | — | No test |
+
+**Coverage:** 8/56 ACs have partial coverage (registration only). 0/56 have functional test coverage.

--- a/docs/user-stories/41_Connectivity_Stories.md
+++ b/docs/user-stories/41_Connectivity_Stories.md
@@ -1,0 +1,128 @@
+# Connectivity User Stories
+
+**Status:** Draft
+**Created:** 2026-04-10
+**Source:** [src/tools/connectivity.ts](../../src/tools/connectivity.ts) | [02_Connectivity_Tools](../reference/02_Connectivity_Tools.md)
+
+---
+
+## US-NET-001: Ping a Host
+
+**Tool:** network_ping | **Ref:** [02_Connectivity_Tools - network_ping](../reference/02_Connectivity_Tools.md#network_ping)
+
+As a user, I want to ping a host so that I can check if it is reachable and measure latency.
+
+### Acceptance Criteria
+
+1. Ping reachable host returns alive=true with response time
+2. Ping unreachable host returns alive=false
+3. Packet count is configurable (default: 1)
+4. Raw ping output is included in response
+5. Invalid hostname returns informative error
+
+### Test Mapping
+
+| AC# | Test Case | Status |
+|-----|-----------|--------|
+| 1 | — | No test |
+| 2 | — | No test |
+| 3 | — | No test |
+| 4 | — | No test |
+| 5 | — | No test |
+
+### Tags
+`network`, `ping`, `diagnostics`
+
+---
+
+## US-NET-002: Check Internet Connectivity
+
+**Tool:** network_check_internet | **Ref:** [02_Connectivity_Tools - network_check_internet](../reference/02_Connectivity_Tools.md#network_check_internet)
+
+As a user, I want to check if the device has internet access so that I can verify connectivity after connecting to WiFi.
+
+### Acceptance Criteria
+
+1. Returns connected=true with latency when internet is available
+2. Returns connected=false when no internet
+3. Falls back through multiple check URLs (Google, Cloudflare, gstatic)
+4. Works without any parameters
+
+### Test Mapping
+
+| AC# | Test Case | Status |
+|-----|-----------|--------|
+| 1 | — | No test |
+| 2 | — | No test |
+| 3 | — | No test |
+| 4 | — | No test |
+
+### Tags
+`network`, `internet`, `diagnostics`
+
+---
+
+## US-NET-003: Detect Captive Portal
+
+**Tool:** network_check_captive | **Ref:** [02_Connectivity_Tools - network_check_captive](../reference/02_Connectivity_Tools.md#network_check_captive)
+
+As a user, I want to detect if I'm behind a captive portal so that I know I need to complete a login page.
+
+### Acceptance Criteria
+
+1. Returns is_captive=false when no portal (HTTP 204 received)
+2. Returns is_captive=true with redirect_url when portal detected (HTTP 302/301)
+3. Provides hint to use browser tools when portal detected
+4. Works without any parameters
+
+### Test Mapping
+
+| AC# | Test Case | Status |
+|-----|-----------|--------|
+| 1 | — | No test |
+| 2 | — | No test |
+| 3 | — | No test |
+| 4 | — | No test |
+
+### Tags
+`network`, `captive-portal`, `diagnostics`
+
+---
+
+## US-NET-004: DNS Lookup
+
+**Tool:** network_dns_lookup | **Ref:** [02_Connectivity_Tools - network_dns_lookup](../reference/02_Connectivity_Tools.md#network_dns_lookup)
+
+As a user, I want to perform a DNS lookup so that I can verify DNS resolution is working.
+
+### Acceptance Criteria
+
+1. Returns resolved IP addresses for valid hostname
+2. Returns both IPv4 and IPv6 addresses when available
+3. Returns error for unresolvable hostname (ENOTFOUND)
+4. Returns error when DNS server is unreachable
+
+### Test Mapping
+
+| AC# | Test Case | Status |
+|-----|-----------|--------|
+| 1 | — | No test |
+| 2 | — | No test |
+| 3 | — | No test |
+| 4 | — | No test |
+
+### Tags
+`network`, `dns`, `diagnostics`
+
+---
+
+## Traceability Matrix
+
+| Story | AC | Test Case | Status |
+|-------|-----|-----------|--------|
+| US-NET-001 | AC1-5 | — | No test |
+| US-NET-002 | AC1-4 | — | No test |
+| US-NET-003 | AC1-4 | — | No test |
+| US-NET-004 | AC1-4 | — | No test |
+
+**Coverage:** 0/17 ACs have test coverage.

--- a/docs/user-stories/42_Browser_Stories.md
+++ b/docs/user-stories/42_Browser_Stories.md
@@ -1,0 +1,102 @@
+# Browser User Stories
+
+**Status:** Draft
+**Created:** 2026-04-10
+**Source:** [src/tools/browser.ts](../../src/tools/browser.ts) | [03_Browser_Tools](../reference/03_Browser_Tools.md)
+
+---
+
+## US-BROW-001: Open URL in Browser
+
+**Tool:** browser_open | **Ref:** [03_Browser_Tools - browser_open](../reference/03_Browser_Tools.md#browser_open)
+
+As a user, I want to open a URL in the system browser so that I can manually interact with a captive portal or web page.
+
+### Acceptance Criteria
+
+1. Valid URL opens in the default system browser
+2. Invalid URL returns informative error
+3. Returns success message with the opened URL
+
+### Test Mapping
+
+| AC# | Test Case | Status |
+|-----|-----------|--------|
+| 1 | — | No test |
+| 2 | — | No test |
+| 3 | — | No test |
+
+### Tags
+`browser`, `open`
+
+---
+
+## US-BROW-002: Run Playwright Automation Script
+
+**Tool:** browser_run_script | **Ref:** [03_Browser_Tools - browser_run_script](../reference/03_Browser_Tools.md#browser_run_script)
+
+As a user, I want to run a Playwright script so that I can automate captive portal logins and browser interactions.
+
+### Acceptance Criteria
+
+1. Script executes and returns output on success
+2. Variables are passed to the script and accessible
+3. Headless mode is configurable (default: false)
+4. Timeout is configurable (default: 60000ms)
+5. Script not found returns informative error
+6. Script timeout returns error with duration
+7. Script failure returns error details
+
+### Test Mapping
+
+| AC# | Test Case | Status |
+|-----|-----------|--------|
+| 1 | — | No test |
+| 2 | — | No test |
+| 3 | — | No test |
+| 4 | — | No test |
+| 5 | — | No test |
+| 6 | — | No test |
+| 7 | — | No test |
+
+### Tags
+`browser`, `script`, `playwright`, `captive-portal`
+
+---
+
+## US-BROW-003: List Available Scripts
+
+**Tool:** browser_list_scripts | **Ref:** [03_Browser_Tools - browser_list_scripts](../reference/03_Browser_Tools.md#browser_list_scripts)
+
+As a user, I want to list available Playwright scripts so that I know which automation scripts are ready to use.
+
+### Acceptance Criteria
+
+1. Returns list of script names in the scripts directory
+2. Returns scripts directory path and count
+3. Empty directory returns empty list with hint
+4. Scripts directory is auto-created if missing
+
+### Test Mapping
+
+| AC# | Test Case | Status |
+|-----|-----------|--------|
+| 1 | — | No test |
+| 2 | — | No test |
+| 3 | — | No test |
+| 4 | — | No test |
+
+### Tags
+`browser`, `scripts`, `list`
+
+---
+
+## Traceability Matrix
+
+| Story | AC | Test Case | Status |
+|-------|-----|-----------|--------|
+| US-BROW-001 | AC1-3 | — | No test |
+| US-BROW-002 | AC1-7 | — | No test |
+| US-BROW-003 | AC1-4 | — | No test |
+
+**Coverage:** 0/14 ACs have test coverage.

--- a/docs/user-stories/43_Credential_Stories.md
+++ b/docs/user-stories/43_Credential_Stories.md
@@ -1,0 +1,138 @@
+# Credential User Stories
+
+**Status:** Draft
+**Created:** 2026-04-10
+**Source:** [src/tools/credentials.ts](../../src/tools/credentials.ts) | [01_WiFi_Tools - Credential Tools](../reference/01_WiFi_Tools.md#credential-tools)
+
+---
+
+## US-CRED-001: Store EAP-TLS Credential
+
+**Tool:** credential_store | **Ref:** [01_WiFi_Tools - credential_store](../reference/01_WiFi_Tools.md#credential_store)
+
+As a user, I want to store EAP-TLS certificates so that I can reuse them for WiFi connections without re-uploading.
+
+### Acceptance Criteria
+
+1. Store with file paths (client cert + private key) creates credential
+2. Auto-generates credential ID from certificate fingerprint when ID omitted
+3. Custom ID with alphanumeric, dash, underscore is accepted
+4. CA certificate is optional
+5. Encrypted private key with password is accepted
+6. Identity is extracted from certificate CN
+7. Invalid certificate file returns informative error
+8. Non-existent file path returns informative error
+9. Credential files are stored with secure permissions (0600)
+
+### Test Mapping
+
+| AC# | Test Case | Status |
+|-----|-----------|--------|
+| 1 | TC-INT-004 | Partial (registration only) |
+| 2 | — | No test |
+| 3 | — | No test |
+| 4 | — | No test |
+| 5 | — | No test |
+| 6 | — | No test |
+| 7 | — | No test |
+| 8 | — | No test |
+| 9 | — | No test |
+
+### Tags
+`credentials`, `store`, `eap-tls`, `certificate`
+
+---
+
+## US-CRED-002: Get Credential Details
+
+**Tool:** credential_get | **Ref:** [01_WiFi_Tools - credential_get](../reference/01_WiFi_Tools.md#credential_get)
+
+As a user, I want to retrieve credential details so that I can verify stored certificate metadata.
+
+### Acceptance Criteria
+
+1. Returns metadata: id, identity, description, timestamps, cert info
+2. include_certs=true returns PEM certificate content
+3. include_certs=false (default) omits PEM content
+4. Non-existent credential ID returns informative error
+
+### Test Mapping
+
+| AC# | Test Case | Status |
+|-----|-----------|--------|
+| 1 | TC-INT-004 | Partial (registration only) |
+| 2 | — | No test |
+| 3 | — | No test |
+| 4 | — | No test |
+
+### Tags
+`credentials`, `get`, `metadata`
+
+---
+
+## US-CRED-003: List All Credentials
+
+**Tool:** credential_list | **Ref:** [01_WiFi_Tools - credential_list](../reference/01_WiFi_Tools.md#credential_list)
+
+As a user, I want to list all stored credentials so that I can see what certificates are available.
+
+### Acceptance Criteria
+
+1. Returns array of credentials with id, identity, description, dates
+2. Returns count of stored credentials
+3. Empty store returns empty array with count 0
+
+### Test Mapping
+
+| AC# | Test Case | Status |
+|-----|-----------|--------|
+| 1 | TC-INT-004 | Partial (registration only) |
+| 2 | — | No test |
+| 3 | — | No test |
+
+### Tags
+`credentials`, `list`
+
+---
+
+## US-CRED-004: Delete a Credential
+
+**Tool:** credential_delete | **Ref:** [01_WiFi_Tools - credential_delete](../reference/01_WiFi_Tools.md#credential_delete)
+
+As a user, I want to delete a stored credential so that I can remove unused or expired certificates.
+
+### Acceptance Criteria
+
+1. Delete by ID removes all certificate files and metadata
+2. Deleted credential no longer appears in credential_list
+3. Non-existent credential ID returns informative error
+4. Deletion is irreversible (documented behavior)
+
+### Test Mapping
+
+| AC# | Test Case | Status |
+|-----|-----------|--------|
+| 1 | TC-INT-004 | Partial (registration only) |
+| 2 | — | No test |
+| 3 | — | No test |
+| 4 | — | No test |
+
+### Tags
+`credentials`, `delete`
+
+---
+
+## Traceability Matrix
+
+| Story | AC | Test Case | Status |
+|-------|-----|-----------|--------|
+| US-CRED-001 | AC1 | TC-INT-004 | Partial (registration only) |
+| US-CRED-001 | AC2-9 | — | No test |
+| US-CRED-002 | AC1 | TC-INT-004 | Partial (registration only) |
+| US-CRED-002 | AC2-4 | — | No test |
+| US-CRED-003 | AC1 | TC-INT-004 | Partial (registration only) |
+| US-CRED-003 | AC2-3 | — | No test |
+| US-CRED-004 | AC1 | TC-INT-004 | Partial (registration only) |
+| US-CRED-004 | AC2-4 | — | No test |
+
+**Coverage:** 4/20 ACs have partial coverage (registration only). 0/20 have functional test coverage.

--- a/docs/user-stories/44_Cross_Cutting_Stories.md
+++ b/docs/user-stories/44_Cross_Cutting_Stories.md
@@ -1,0 +1,115 @@
+# Cross-Cutting User Stories
+
+**Status:** Draft
+**Created:** 2026-04-10
+**Source:** [src/lib/mac-utils.ts](../../src/lib/mac-utils.ts) | [mac-address-restoration](../design/mac-address-restoration.md) | [05_Docker_Netns_Isolation](../reference/05_Docker_Netns_Isolation.md)
+
+---
+
+## US-MAC-001: MAC Address Privacy
+
+**Tools:** wifi_connect, wifi_connect_eap, wifi_connect_tls, wifi_hs20_connect | **Ref:** [01_WiFi_Tools - MAC Modes](../reference/01_WiFi_Tools.md#wifi_connect)
+
+As a user, I want to control my MAC address per connection so that I can protect my privacy or use my real MAC when required.
+
+### Acceptance Criteria
+
+1. mac_mode="random" uses a new random MAC for each connection
+2. mac_mode="persistent-random" uses the same random MAC across reboots
+3. mac_mode="device" uses the real hardware MAC
+4. mac_mode="specific" with mac_address uses the provided MAC
+5. preassoc_mac_mode="random" randomizes MAC during scanning
+6. rand_addr_lifetime controls MAC rotation interval
+7. MAC modes work across all four connection tools (PSK, EAP, TLS, HS20)
+8. Invalid MAC format returns validation error
+
+### Test Mapping
+
+| AC# | Test Case | Status |
+|-----|-----------|--------|
+| 1 | — | No test |
+| 2 | — | No test |
+| 3 | — | No test |
+| 4 | — | No test |
+| 5 | — | No test |
+| 6 | — | No test |
+| 7 | — | No test |
+| 8 | — | No test |
+
+### Tags
+`mac`, `privacy`, `cross-cutting`
+
+---
+
+## US-MAC-002: Permanent MAC Restoration in Docker
+
+**Tools:** wifi_connect, wifi_connect_eap, wifi_connect_tls, wifi_hs20_connect | **Ref:** [mac-address-restoration](../design/mac-address-restoration.md)
+
+As a user running in Docker, I want device mode to use my real hardware MAC so that MAC-based RADIUS authentication works without manual lookup.
+
+### Acceptance Criteria
+
+1. mac_mode="device" in Docker restores permanent MAC (not kernel-assigned)
+2. Permanent MAC is read from `ip link show` permaddr at daemon startup
+3. MAC restoration stops/restarts wpa_supplicant transparently
+4. MAC restoration failure is non-fatal (connection still attempted)
+5. No-op when current MAC already matches permanent MAC
+
+### Test Mapping
+
+| AC# | Test Case | Status |
+|-----|-----------|--------|
+| 1 | — | No test |
+| 2 | — | No test |
+| 3 | — | No test |
+| 4 | — | No test |
+| 5 | — | No test |
+
+### Tags
+`mac`, `docker`, `device-mode`, `cross-cutting`
+
+---
+
+## US-DOCK-001: Docker Network Namespace Isolation
+
+**Ref:** [05_Docker_Netns_Isolation](../reference/05_Docker_Netns_Isolation.md) | [30_Docker_Dev_Plan](../plans/30_Docker_Dev_Plan.md)
+
+As a user, I want WiFi to be fully isolated in the Docker container so that WiFi routes don't pollute the host routing table.
+
+### Acceptance Criteria
+
+1. WiFi phy is moved into container netns via `iw phy set netns`
+2. WiFi interface disappears from host after phy move
+3. Host routing table is unaffected during connect/disconnect
+4. WiFi is the sole default route inside the container (bridge default deleted)
+5. MCP client reaches container via Docker bridge subnet
+6. Phy returns to host when container stops
+
+### Test Mapping
+
+| AC# | Test Case | Status |
+|-----|-----------|--------|
+| 1 | TC-BUILD-002 | Partial (Docker build only) |
+| 2 | — | No test |
+| 3 | — | No test |
+| 4 | — | No test |
+| 5 | TC-INT-001 | Partial (health check only) |
+| 6 | — | No test |
+
+### Tags
+`docker`, `netns`, `isolation`, `cross-cutting`
+
+---
+
+## Traceability Matrix
+
+| Story | AC | Test Case | Status |
+|-------|-----|-----------|--------|
+| US-MAC-001 | AC1-8 | — | No test |
+| US-MAC-002 | AC1-5 | — | No test |
+| US-DOCK-001 | AC1 | TC-BUILD-002 | Partial (Docker build) |
+| US-DOCK-001 | AC2-4 | — | No test |
+| US-DOCK-001 | AC5 | TC-INT-001 | Partial (health check) |
+| US-DOCK-001 | AC6 | — | No test |
+
+**Coverage:** 2/19 ACs have partial coverage. 0/19 have functional test coverage.


### PR DESCRIPTION
## Summary

- Add 27 user stories covering all 22 MCP tools plus 3 cross-cutting concerns
- Each story has acceptance criteria mapped to existing test cases
- Traceability matrices reveal test coverage gaps
- Update docs/README.md index with all 5 story files

## Stories by Domain

| File | Stories | ACs | Coverage |
|------|---------|-----|----------|
| 40_WiFi_Stories.md | 13 | 56 | 8 partial (registration) |
| 41_Connectivity_Stories.md | 4 | 17 | 0 |
| 42_Browser_Stories.md | 3 | 14 | 0 |
| 43_Credential_Stories.md | 4 | 20 | 0 |
| 44_Cross_Cutting_Stories.md | 3 | 19 | 2 partial |
| **Total** | **27** | **126** | **14/126 partial, 0 functional** |

## Test plan

- [ ] Verify all story files render correctly on GitHub
- [ ] Verify cross-references to reference/design docs resolve
- [ ] Verify traceability matrices match existing test case IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)