### PR TITLE
Daemonize wpa-mcp: systemd service + persistent credential store

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,11 @@ WPA_CONFIG_PATH=/etc/wpa_supplicant/wpa_supplicant.conf
 # Debug settings (1=basic, 2=verbose, 3=maximum)
 WPA_DEBUG_LEVEL=2
 
+# Docker named volume for the credential store. Mounted at
+# /home/node/.config/wpa-mcp so credentials added at runtime via the
+# credential_store MCP tool persist across container restarts.
+# WPA_MCP_VOLUME=wpa-mcp-data
+
 # Playwright scripts directory
 # WPA_MCP_SCRIPTS_DIR=~/.config/wpa-mcp/scripts
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # wpa-mcp Makefile
 # Development build and Docker deployment
 
-.PHONY: build clean help upload-certs nm-unmanage nm-restore docker-build docker-start docker-stop docker-restart docker-logs docker-status docker-shell
+.PHONY: build clean help upload-certs nm-unmanage nm-restore docker-build docker-start docker-stop docker-restart docker-logs docker-status docker-shell install-systemd uninstall-systemd
 
 # Load .env if exists
 -include .env
@@ -31,6 +31,10 @@ help:
 	@echo "Network setup:"
 	@echo "  nm-unmanage      - Persistently unmanage WiFi interface from NetworkManager"
 	@echo "  nm-restore       - Restore NetworkManager management of WiFi interface"
+	@echo ""
+	@echo "systemd daemon:"
+	@echo "  install-systemd    - Install /etc/systemd/system/wpa-mcp.service and wrapper"
+	@echo "  uninstall-systemd  - Remove the service and wrapper"
 	@echo ""
 	@echo "Certificate upload (configure in .env or pass as args):"
 	@echo "  upload-certs CERT_REMOTE_HOST=user@host \\"
@@ -102,6 +106,45 @@ upload-certs:
 	@if [ -n "$(CERT_CA)" ] && [ -f "$(CERT_CA)" ]; then \
 		echo "  ca_cert_path: $(CERT_REMOTE_DIR)/ca.crt"; \
 	fi
+
+# systemd: install daemon so wpa-mcp starts automatically on boot.
+# Usage: sudo make install-systemd [WIFI_INTERFACE=wlp0s20f3]
+SYSTEMD_UNIT := /etc/systemd/system/wpa-mcp.service
+SYSTEMD_WRAPPER := /usr/local/sbin/wpa-mcp-start
+
+install-systemd:
+	@if [ "$$(id -u)" -ne 0 ]; then \
+		echo "Error: must run as root"; \
+		echo "Usage: sudo make install-systemd [WIFI_INTERFACE=$(WIFI_INTERFACE)]"; \
+		exit 1; \
+	fi
+	install -m 0755 deploy/wpa-mcp-start $(SYSTEMD_WRAPPER)
+	install -m 0644 deploy/wpa-mcp.service $(SYSTEMD_UNIT)
+	@if [ -n "$(WIFI_INTERFACE)" ] && [ "$(WIFI_INTERFACE)" != "wlan0" ]; then \
+		sed -i "s|^Environment=WIFI_INTERFACE=.*|Environment=WIFI_INTERFACE=$(WIFI_INTERFACE)|" $(SYSTEMD_UNIT); \
+		echo "Set WIFI_INTERFACE=$(WIFI_INTERFACE) in $(SYSTEMD_UNIT)"; \
+	fi
+	systemctl daemon-reload
+	@echo ""
+	@echo "Installed:"
+	@echo "  $(SYSTEMD_WRAPPER)"
+	@echo "  $(SYSTEMD_UNIT)"
+	@echo ""
+	@echo "Enable on boot and start now:"
+	@echo "  sudo systemctl enable --now wpa-mcp"
+
+uninstall-systemd:
+	@if [ "$$(id -u)" -ne 0 ]; then \
+		echo "Error: must run as root"; \
+		echo "Usage: sudo make uninstall-systemd"; \
+		exit 1; \
+	fi
+	-systemctl disable --now wpa-mcp.service 2>/dev/null
+	-rm -f $(SYSTEMD_UNIT) $(SYSTEMD_WRAPPER)
+	systemctl daemon-reload
+	@echo "Removed $(SYSTEMD_UNIT) and $(SYSTEMD_WRAPPER)"
+	@echo "Note: Docker volume 'wpa-mcp-data' is preserved. Remove with:"
+	@echo "  docker volume rm wpa-mcp-data"
 
 # NetworkManager: persistently unmanage WiFi interface
 # Creates a drop-in config so NM ignores the interface across reboots.

--- a/README.md
+++ b/README.md
@@ -131,6 +131,14 @@ sudo make uninstall-systemd
 
 The wrapper script lives in `/usr/local/sbin/` (no dependency on any user home directory), so it works even when `/home` is not yet available at boot.
 
+**Container crash recovery:** The service is `Type=oneshot, RemainAfterExit=yes`, which means systemd tracks the wrapper's exit, not the container itself. If the container dies at runtime (docker daemon crash, OOM kill), systemd will continue to report the unit as `active (exited)` but nothing is running. Recover with:
+
+```bash
+sudo systemctl restart wpa-mcp
+```
+
+`.env` at the project root is read by `make docker-start` only. The systemd install reads from the `Environment=` lines in `/etc/systemd/system/wpa-mcp.service` — edit that file (and `systemctl daemon-reload`) to change values for the daemon path.
+
 ### Persistent credential store
 
 When started via either `make docker-start` or the systemd unit, a Docker named volume `wpa-mcp-data` is mounted at `/home/node/.config/wpa-mcp` inside the container. Credentials added at runtime via the `credential_store` MCP tool persist across container restarts, image rebuilds, and host reboots.

--- a/README.md
+++ b/README.md
@@ -107,6 +107,45 @@ make docker-stop
 sudo make nm-restore WIFI_INTERFACE=wlp6s0
 ```
 
+### Auto-start on boot (systemd)
+
+To make wpa-mcp come up automatically on every reboot, install the systemd unit:
+
+```bash
+sudo make install-systemd WIFI_INTERFACE=wlp6s0
+sudo systemctl enable --now wpa-mcp
+```
+
+This installs:
+
+| Path | Purpose |
+|------|---------|
+| `/usr/local/sbin/wpa-mcp-start` | Wrapper that does `docker run` + `iw phy set netns` + health-wait |
+| `/etc/systemd/system/wpa-mcp.service` | `Type=oneshot, RemainAfterExit=yes`, `After=docker.service` |
+
+Uninstall:
+
+```bash
+sudo make uninstall-systemd
+```
+
+The wrapper script lives in `/usr/local/sbin/` (no dependency on any user home directory), so it works even when `/home` is not yet available at boot.
+
+### Persistent credential store
+
+When started via either `make docker-start` or the systemd unit, a Docker named volume `wpa-mcp-data` is mounted at `/home/node/.config/wpa-mcp` inside the container. Credentials added at runtime via the `credential_store` MCP tool persist across container restarts, image rebuilds, and host reboots.
+
+Baked certs under `certs/` are separate: they are copied into the image at build time and re-imported (idempotently) on every container start.
+
+```bash
+# Inspect the volume
+docker volume inspect wpa-mcp-data
+
+# Wipe stored credentials (container must be stopped first)
+sudo systemctl stop wpa-mcp
+docker volume rm wpa-mcp-data
+```
+
 See [docs/05_Structure_and_Flow.md](docs/05_Structure_and_Flow.md) for the full netns architecture and route trace.
 
 ---

--- a/deploy/wpa-mcp-start
+++ b/deploy/wpa-mcp-start
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+#
+# wpa-mcp-start -- start wpa-mcp container and move WiFi phy into its netns.
+#
+# Designed to be called by wpa-mcp.service (systemd). Lives in
+# /usr/local/sbin/ so it has no dependency on any user home directory.
+#
+# Configuration via environment (set in the systemd unit or the shell):
+#   WIFI_INTERFACE    WiFi interface name                (default: wlan0)
+#   WPA_MCP_IMAGE     Docker image tag                   (default: wpa-mcp:latest)
+#   PORT              Host port to forward               (default: 3000)
+#   WPA_DEBUG_LEVEL   wpa_supplicant debug verbosity 1-3 (default: 2)
+#   WPA_MCP_VOLUME    Named volume for credential store  (default: wpa-mcp-data)
+#
+set -euo pipefail
+
+IFACE="${WIFI_INTERFACE:-wlan0}"
+IMAGE="${WPA_MCP_IMAGE:-wpa-mcp:latest}"
+PORT="${PORT:-3000}"
+DEBUG_LEVEL="${WPA_DEBUG_LEVEL:-2}"
+VOLUME="${WPA_MCP_VOLUME:-wpa-mcp-data}"
+CONTAINER="wpa-mcp"
+
+# On systemctl restart, ExecStop removes the container and the kernel
+# returns the phy to the host; give the interface a moment to reappear.
+for _ in $(seq 1 15); do
+  [[ -d /sys/class/net/$IFACE ]] && break
+  sleep 1
+done
+if [[ ! -d /sys/class/net/$IFACE ]]; then
+  echo "error: interface $IFACE not present on host" >&2
+  exit 1
+fi
+
+PHY=$(cat "/sys/class/net/$IFACE/phy80211/name")
+
+docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+ip link set "$IFACE" down 2>/dev/null || true
+
+docker run --rm -d \
+  --name "$CONTAINER" \
+  --cap-add NET_ADMIN --cap-add NET_RAW \
+  -p "$PORT:3000" \
+  -v "$VOLUME:/home/node/.config/wpa-mcp" \
+  -e "WIFI_INTERFACE=$IFACE" \
+  -e "WPA_DEBUG_LEVEL=$DEBUG_LEVEL" \
+  -e "PORT=3000" \
+  "$IMAGE" >/dev/null
+
+PID=$(docker inspect --format '{{.State.Pid}}' "$CONTAINER")
+if [[ -z "$PID" || "$PID" == "0" ]]; then
+  echo "error: could not resolve container PID" >&2
+  exit 1
+fi
+
+iw phy "$PHY" set netns "$PID"
+
+for _ in $(seq 1 30); do
+  if curl -sf "http://localhost:$PORT/health" >/dev/null 2>&1; then
+    echo "wpa-mcp: healthy (phy $PHY in container PID $PID, volume $VOLUME)"
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "error: health check failed after 30s" >&2
+exit 1

--- a/deploy/wpa-mcp-start
+++ b/deploy/wpa-mcp-start
@@ -21,6 +21,13 @@ DEBUG_LEVEL="${WPA_DEBUG_LEVEL:-2}"
 VOLUME="${WPA_MCP_VOLUME:-wpa-mcp-data}"
 CONTAINER="wpa-mcp"
 
+for cmd in docker iw curl ip; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "error: required command '$cmd' not found on PATH" >&2
+    exit 1
+  fi
+done
+
 # On systemctl restart, ExecStop removes the container and the kernel
 # returns the phy to the host; give the interface a moment to reappear.
 for _ in $(seq 1 15); do

--- a/deploy/wpa-mcp.service
+++ b/deploy/wpa-mcp.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=wpa-mcp WiFi control MCP server (Docker + netns phy)
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+
+# Edit these to match your host. WIFI_INTERFACE in particular must be set
+# to the wireless interface you want the container to own.
+Environment=WIFI_INTERFACE=wlan0
+Environment=WPA_MCP_IMAGE=wpa-mcp:latest
+Environment=PORT=3000
+Environment=WPA_DEBUG_LEVEL=2
+Environment=WPA_MCP_VOLUME=wpa-mcp-data
+
+ExecStart=/usr/local/sbin/wpa-mcp-start
+ExecStop=/usr/bin/docker rm -f wpa-mcp
+
+[Install]
+WantedBy=multi-user.target

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -53,6 +53,12 @@ RUN mkdir -p /etc/wpa_supplicant && \
 # Create wpa_supplicant runtime directory
 RUN mkdir -p /var/run/wpa_supplicant
 
+# Pre-create credential store dir with node ownership so a mounted
+# named volume inherits correct perms (Docker copies image ownership
+# into a fresh volume on first mount).
+RUN mkdir -p /home/node/.config/wpa-mcp/credentials && \
+    chown -R node:node /home/node/.config
+
 WORKDIR /app
 
 # Copy built application and production dependencies from builder

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -109,6 +109,7 @@ docker run --rm -d \
   --cap-add NET_ADMIN \
   --cap-add NET_RAW \
   -p "${HOST_PORT}:3000" \
+  -v "${WPA_MCP_VOLUME:-wpa-mcp-data}:/home/node/.config/wpa-mcp" \
   -e "WIFI_INTERFACE=${IFACE}" \
   -e "WPA_DEBUG_LEVEL=${DEBUG_LEVEL}" \
   -e "PORT=3000" \


### PR DESCRIPTION
Closes #40.

## Summary

- Ships `deploy/wpa-mcp.service` and `deploy/wpa-mcp-start` so wpa-mcp comes up automatically on host reboot.
- Mounts a Docker named volume `wpa-mcp-data` at `/home/node/.config/wpa-mcp` so credentials added at runtime via the `credential_store` MCP tool persist across container restarts, image rebuilds, and host reboots.

## Changes

| File | Change |
|------|--------|
| `docker/Dockerfile` | Pre-create `/home/node/.config/wpa-mcp/credentials` with `node:node` ownership so a fresh named volume inherits correct perms |
| `docker/run.sh` | Mount `wpa-mcp-data:/home/node/.config/wpa-mcp` |
| `deploy/wpa-mcp-start` | Root-owned wrapper, env-driven, no home-dir dependency |
| `deploy/wpa-mcp.service` | `Type=oneshot, RemainAfterExit=yes`, `After=docker.service` |
| `Makefile` | `install-systemd` / `uninstall-systemd` targets |
| `README.md` | Daemon install section + volume documentation |

## Design notes

**Why a root-owned wrapper instead of pointing systemd at `docker/run.sh` directly?** Systemd services shouldn't reach into `/home/<user>/` — at early boot `/home` may not be mounted/decrypted/permitted. `/usr/local/sbin/wpa-mcp-start` is system-owned and always available.

**Why not `--restart=unless-stopped`?** Docker's restart policy can relaunch the container, but it can't re-run `iw phy set netns <new_pid>`. The phy would stay orphaned in the old netns. A systemd unit that owns the whole dance (docker run + phy move) is the clean answer.

**Why pre-create the cred directory in the Dockerfile?** When Docker creates a fresh named volume and mounts it on a path that the image *did* create, it copies the image's ownership into the new volume. Without the mkdir+chown, the volume starts root-owned and the `node` user can't write.

## Verification on my host

- Installed via `sudo make install-systemd WIFI_INTERFACE=wlp0s20f3` + `sudo systemctl enable --now wpa-mcp`
- Rebooted the host; service came up automatically, container healthy, phy in container netns
- A runtime credential stored in the volume survived: reboot, `systemctl restart`, image rebuild, removal of source cert from `certs/`

## Test plan

- [x] Build suite (`--suite build --no-llm`) passes locally
- [x] Integration suite (`--suite integration --no-llm`) passes locally (19/19)
- [x] `sudo make install-systemd` installs unit + wrapper, `systemctl daemon-reload` runs cleanly
- [x] `sudo systemctl enable --now wpa-mcp` starts container and injects phy
- [x] `systemctl restart wpa-mcp` cleanly cycles container and re-injects phy
- [x] Reboot: service auto-starts, credential `b108704b71c48cbb` (user02@tsengsyu.com) persists in `wpa-mcp-data`
- [x] `sudo make uninstall-systemd` removes unit + wrapper; volume is intentionally preserved (message printed)

## Out of scope / follow-ups

- Persisting `/etc/wpa_supplicant/wpa_supplicant.conf` so saved PSKs from `wifi_connect` also survive restart. The entrypoint writes to this file at boot, so it needs a different shape — tracked for a future PR if/when needed.
- No changes to GitHub Actions CI; the workflow is still `workflow_dispatch` only.