### PR TITLE
Run Microsoft Playwright MCP inside the container, proxied at /playwright-mcp

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@ This is an MCP (Model Context Protocol) server that provides WiFi control via wp
 
 ### Key Components
 
-- **src/index.ts** - Entry point. Creates Express server, MCP server, WpaDaemon, and DhcpManager. Registers all tools.
+- **src/index.ts** - Entry point. Creates Express server, MCP server, WpaDaemon, and DhcpManager. Registers all tools. Also mounts a reverse proxy at `/playwright-mcp` that forwards to the [Microsoft Playwright MCP](https://github.com/microsoft/playwright-mcp) subprocess running on `127.0.0.1:8931` inside the container. The proxy intercepts the `initialize` response (both JSON and SSE bodies) and injects a `result.instructions` string so MCP clients automatically see a "when to pick this server" description. The subprocess is launched by `docker/entrypoint.sh`.
 
 - **src/tools/** - MCP tool definitions using Zod schemas for validation:
   - `wifi.ts` - WiFi management tools (scan, connect, connect_eap, connect_tls, hs20_connect, disconnect, status, etc.)
@@ -110,6 +110,17 @@ This is an MCP (Model Context Protocol) server that provides WiFi control via wp
 ### Tool Registration Pattern
 
 Tools are registered with `server.tool(name, description, zodSchema, handler)`. The handler receives validated parameters and returns `{ content: [{ type: 'text', text: JSON.stringify(...) }] }`.
+
+### Dual-MCP Architecture
+
+The container exposes **two** MCP endpoints on a single port (3000):
+
+| Path | Mode | Tools | Runs as |
+|---|---|---|---|
+| `/mcp` | Stateless Streamable HTTP | `wifi_*`, `credential_*`, `network_*`, `browser_open`, `browser_run_script`, `browser_list_scripts` | In-process (this server) |
+| `/playwright-mcp` | Stateful (proxied) | `browser_navigate`, `browser_click`, `browser_fill_form`, `browser_snapshot`, etc. | `@playwright/mcp` subprocess on `127.0.0.1:8931`, launched by the entrypoint |
+
+Why two endpoints: the stock Microsoft Playwright MCP gives step-by-step browser control that scripted Playwright doesn't. By running it inside this container, any browser it launches shares the WiFi network namespace and can reach captive portals the host never sees. The reverse proxy keeps only port 3000 exposed externally and tags the upstream `initialize` response with intent-disclosure instructions so agents know when to pick this over the stock `playwright` MCP.
 
 ### wpa_supplicant Integration
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ MCP (Model Context Protocol) server for WiFi control via wpa_supplicant. Enables
 | Privacy | Per-connection MAC randomization, pre-association MAC |
 | Diagnostics | EAP state/decision, filtered debug logs (eap, state, scan, error) |
 | Connectivity | Ping, DNS lookup, internet check, captive portal detection |
-| Browser Automation | Playwright scripts for captive portal login |
+| Browser Automation | Scripted Playwright runner + proxied **Microsoft Playwright MCP** for full step-by-step browser control inside the container's network namespace |
 
 ---
 
@@ -92,10 +92,20 @@ docker exec wpa-mcp ip route
 
 ### Step 5: Register MCP client
 
+The container exposes **two** MCP endpoints on a single port:
+
+| Endpoint | What it is |
+|---|---|
+| `/mcp` | wpa-mcp itself — WiFi, credentials, connectivity, scripted Playwright |
+| `/playwright-mcp` | Proxied [Microsoft Playwright MCP](https://github.com/microsoft/playwright-mcp) — step-by-step browser control, browser runs **inside the container's network namespace** so it reaches captive portals on the WLAN joined via `wifi_connect` |
+
 ```bash
 # Claude Code (from host or any machine that can reach port 3000)
-claude mcp add wpa-mcp --transport http http://localhost:3000/mcp
+claude mcp add wpa-mcp         --transport http http://localhost:3000/mcp
+claude mcp add wpa-playwright  --transport http http://localhost:3000/playwright-mcp
 ```
+
+The proxied Playwright MCP advertises its intent via the MCP `instructions` field, so agents registering this endpoint automatically see a "when to pick this server" description. For general browsing on the host's internet, register the stock `@playwright/mcp` separately.
 
 ### Cleanup
 
@@ -150,7 +160,8 @@ Credentials can also be added at runtime via the `credential_store` MCP tool, bu
 ### Claude Code
 
 ```bash
-claude mcp add wpa-mcp --transport http http://<HOST_IP>:3000/mcp
+claude mcp add wpa-mcp         --transport http http://<HOST_IP>:3000/mcp
+claude mcp add wpa-playwright  --transport http http://<HOST_IP>:3000/playwright-mcp
 ```
 
 ### Claude Desktop
@@ -162,6 +173,9 @@ Add to `claude_desktop_config.json`:
   "mcpServers": {
     "wpa-mcp": {
       "url": "http://<HOST_IP>:3000/mcp"
+    },
+    "wpa-playwright": {
+      "url": "http://<HOST_IP>:3000/playwright-mcp"
     }
   }
 }
@@ -271,7 +285,8 @@ Copy `.env.example` to `.env`. Key settings:
 
 ## API Endpoints
 
-- `POST /mcp` -- MCP protocol endpoint (Streamable HTTP)
+- `POST /mcp` -- wpa-mcp MCP protocol endpoint (Streamable HTTP, stateless)
+- `POST|GET|DELETE /playwright-mcp` -- reverse proxy to the in-container Microsoft Playwright MCP (stateful; Mcp-Session-Id required after initialize)
 - `GET /health` -- Health check
 
 ---

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,6 +28,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     sudo \
   && rm -rf /var/lib/apt/lists/*
 
+# Microsoft Playwright MCP server (runs alongside wpa-mcp, shares network namespace).
+# Install globally so `npx @playwright/mcp` resolves without a network fetch at startup.
+# Chromium is downloaded on first browser launch into /home/node/.cache/ms-playwright.
+RUN npm install -g @playwright/mcp@latest
+
 # Allow node user to run only the specific privileged commands needed
 # for WiFi control, DHCP, and network configuration
 RUN printf 'node ALL=(ALL) NOPASSWD: \\\n\

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,10 +28,30 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     sudo \
   && rm -rf /var/lib/apt/lists/*
 
-# Microsoft Playwright MCP server (runs alongside wpa-mcp, shares network namespace).
-# Install globally so `npx @playwright/mcp` resolves without a network fetch at startup.
-# Chromium is downloaded on first browser launch into /home/node/.cache/ms-playwright.
-RUN npm install -g @playwright/mcp@latest
+# Microsoft Playwright MCP server (runs alongside wpa-mcp, shares network
+# namespace). Installed globally so the `playwright-mcp` binary is on PATH
+# without a network fetch at container start (the entrypoint deletes the
+# default route to make WiFi the sole default).
+#
+# Pinned to an exact version for reproducible builds; bump deliberately.
+RUN npm install -g @playwright/mcp@0.0.70
+
+# Pre-install Chromium + its system libs at build time. Two reasons:
+# 1. At runtime the container has no default route, so any on-demand
+#    Playwright download (~170 MiB) would hang indefinitely.
+# 2. Chromium in Debian 12 needs ~25 shared libs (libnss3, libgbm1,
+#    libatk*, libcairo2, libpango-1.0-0, libasound2, etc.). `playwright
+#    install-deps` resolves the exact set via apt.
+#
+# PLAYWRIGHT_BROWSERS_PATH pins the cache to a predictable shared path so
+# the root install (here) and the node-user runtime (playwright-mcp)
+# read from the same location.
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+RUN mkdir -p /ms-playwright \
+ && node /usr/local/lib/node_modules/@playwright/mcp/node_modules/playwright-core/cli.js install-deps chromium \
+ && node /usr/local/lib/node_modules/@playwright/mcp/node_modules/playwright-core/cli.js install chromium \
+ && chown -R node:node /ms-playwright \
+ && rm -rf /var/lib/apt/lists/*
 
 # Allow node user to run only the specific privileged commands needed
 # for WiFi control, DHCP, and network configuration

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -41,5 +41,18 @@ if [ -d /app/certs ] && [ "$(ls -A /app/certs 2>/dev/null)" ]; then
   node /app/scripts/import-certs.mjs || echo "entrypoint: cert import failed (non-fatal)"
 fi
 
+# Start Microsoft Playwright MCP in the background so a browser launched
+# by that server shares this container's network namespace -- essential for
+# reaching captive portals on the WLAN joined via wifi_connect. Bound to
+# loopback only; external clients reach it via wpa-mcp's /playwright-mcp
+# reverse proxy (which also injects a server-level `instructions` string
+# describing the intent so agents know when to pick this server).
+PLAYWRIGHT_MCP_PORT="${PLAYWRIGHT_MCP_PORT:-8931}"
+echo "entrypoint: starting Microsoft Playwright MCP on 127.0.0.1:${PLAYWRIGHT_MCP_PORT}"
+# Use the binary directly, not `npx`, because the container has no default
+# route to npm's registry (entrypoint deletes the Docker bridge default).
+playwright-mcp --port "${PLAYWRIGHT_MCP_PORT}" --host 127.0.0.1 \
+  > /tmp/playwright-mcp.log 2>&1 &
+
 # Hand off to Node.js server
 exec node dist/index.js "$@"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -51,8 +51,40 @@ PLAYWRIGHT_MCP_PORT="${PLAYWRIGHT_MCP_PORT:-8931}"
 echo "entrypoint: starting Microsoft Playwright MCP on 127.0.0.1:${PLAYWRIGHT_MCP_PORT}"
 # Use the binary directly, not `npx`, because the container has no default
 # route to npm's registry (entrypoint deletes the Docker bridge default).
-playwright-mcp --port "${PLAYWRIGHT_MCP_PORT}" --host 127.0.0.1 \
+# Flags follow the upstream @playwright/mcp Docker guidance:
+#   --headless          no display server available in the container
+#   --browser chromium  use the Playwright-packaged Chromium (pre-baked
+#                       into the image at PLAYWRIGHT_BROWSERS_PATH)
+#   --no-sandbox        Chromium's setuid sandbox needs caps we don't grant
+# Launched from /tmp because playwright-mcp creates a `.playwright-mcp/`
+# artifact dir in its CWD; /app is owned by root and the node user cannot
+# write there.
+(cd /tmp && playwright-mcp \
+  --headless \
+  --browser chromium \
+  --no-sandbox \
+  --port "${PLAYWRIGHT_MCP_PORT}" \
+  --host 127.0.0.1) \
   > /tmp/playwright-mcp.log 2>&1 &
+PLAYWRIGHT_MCP_PID=$!
+
+# Sanity-check: wait briefly for playwright-mcp to bind so a failure to
+# launch surfaces as a clear log line instead of opaque 500s from the
+# reverse proxy at runtime.
+for i in 1 2 3 4 5; do
+  if ! kill -0 "$PLAYWRIGHT_MCP_PID" 2>/dev/null; then
+    echo "entrypoint: ERROR -- playwright-mcp exited during startup; see /tmp/playwright-mcp.log"
+    break
+  fi
+  if ss -tln 2>/dev/null | grep -q ":${PLAYWRIGHT_MCP_PORT} "; then
+    echo "entrypoint: playwright-mcp listening on 127.0.0.1:${PLAYWRIGHT_MCP_PORT} (pid ${PLAYWRIGHT_MCP_PID})"
+    break
+  fi
+  sleep 1
+  if [ "$i" = 5 ]; then
+    echo "entrypoint: WARNING -- playwright-mcp did not bind to ${PLAYWRIGHT_MCP_PORT} within 5s; the /playwright-mcp proxy will fail. See /tmp/playwright-mcp.log"
+  fi
+done
 
 # Hand off to Node.js server
 exec node dist/index.js "$@"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -51,20 +51,33 @@ PLAYWRIGHT_MCP_PORT="${PLAYWRIGHT_MCP_PORT:-8931}"
 echo "entrypoint: starting Microsoft Playwright MCP on 127.0.0.1:${PLAYWRIGHT_MCP_PORT}"
 # Use the binary directly, not `npx`, because the container has no default
 # route to npm's registry (entrypoint deletes the Docker bridge default).
-# Flags follow the upstream @playwright/mcp Docker guidance:
-#   --headless          no display server available in the container
-#   --browser chromium  use the Playwright-packaged Chromium (pre-baked
-#                       into the image at PLAYWRIGHT_BROWSERS_PATH)
-#   --no-sandbox        Chromium's setuid sandbox needs caps we don't grant
-# Launched from /tmp because playwright-mcp creates a `.playwright-mcp/`
-# artifact dir in its CWD; /app is owned by root and the node user cannot
-# write there.
-(cd /tmp && playwright-mcp \
+# Flags follow the upstream @playwright/mcp Docker guidance, adapted
+# for this container:
+#   --headless                        no display server in the container
+#   --browser chromium                use the Playwright-packaged Chromium
+#                                     (pre-baked at PLAYWRIGHT_BROWSERS_PATH)
+#   --no-sandbox                      Chromium's setuid sandbox needs caps
+#                                     we don't grant
+#   --allow-unrestricted-file-access  MCP clients send their host
+#                                     workspace path (e.g. `/home/jack`)
+#                                     as the root, which doesn't exist
+#                                     in the container; bypass the check
+#   --output-dir /tmp/playwright-mcp  Pin the artifact directory. Without
+#                                     this, Playwright MCP defaults to
+#                                     `<client.cwd>/.playwright-mcp`, and
+#                                     mkdir -p on `/home/jack/...` fails
+#                                     with EACCES as the node user. /tmp
+#                                     is always writable.
+PLAYWRIGHT_MCP_OUTPUT_DIR=/tmp/playwright-mcp-output
+mkdir -p "$PLAYWRIGHT_MCP_OUTPUT_DIR"
+playwright-mcp \
   --headless \
   --browser chromium \
   --no-sandbox \
+  --allow-unrestricted-file-access \
+  --output-dir "$PLAYWRIGHT_MCP_OUTPUT_DIR" \
   --port "${PLAYWRIGHT_MCP_PORT}" \
-  --host 127.0.0.1) \
+  --host 127.0.0.1 \
   > /tmp/playwright-mcp.log 2>&1 &
 PLAYWRIGHT_MCP_PID=$!
 

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -112,6 +112,7 @@ docker run --rm -d \
   -e "WIFI_INTERFACE=${IFACE}" \
   -e "WPA_DEBUG_LEVEL=${DEBUG_LEVEL}" \
   -e "PORT=3000" \
+  -e "PLAYWRIGHT_MCP_PORT=8931" \
   "$IMAGE"
 
 # --- Move WiFi phy into container netns ---
@@ -167,8 +168,11 @@ echo "Verify container:"
 echo "  docker exec $CONTAINER_NAME ip link show $CONTAINER_IFACE"
 echo "  docker exec $CONTAINER_NAME ip route"
 echo ""
-echo "MCP endpoint: http://localhost:${HOST_PORT}/mcp"
-echo "Health check: curl http://localhost:${HOST_PORT}/health"
+echo "wpa-mcp endpoint:        http://localhost:${HOST_PORT}/mcp"
+echo "Playwright MCP endpoint: http://localhost:${HOST_PORT}/playwright-mcp"
+echo "  (proxied to Microsoft Playwright MCP running on 127.0.0.1:8931 inside the container;"
+echo "   browsers it launches route through the Wi-Fi joined via wifi_connect)"
+echo "Health check:            curl http://localhost:${HOST_PORT}/health"
 echo ""
 echo "To stop and return phy to host:"
 echo "  docker rm -f $CONTAINER_NAME"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@modelcontextprotocol/sdk": "^1.12.0",
         "dotenv": "^17.2.3",
         "express": "^4.21.0",
+        "http-proxy-middleware": "^3.0.5",
         "is-online": "^10.0.0",
         "open": "^10.1.0",
         "playwright": "^1.49.0",
@@ -434,6 +435,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/http-proxy": {
+      "version": "1.17.17",
+      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.17.tgz",
+      "integrity": "sha512-ED6LB+Z1AVylNTu7hdzuBqOgMnvG/ld6wGCG8wFnAzKX5uyW2K3WD52v0gnLCTK/VLpXtKckgWuyScYK6cSPaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
@@ -445,7 +455,6 @@
       "version": "22.19.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.1.tgz",
       "integrity": "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -603,6 +612,18 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/bundle-name": {
@@ -989,6 +1010,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
     "node_modules/eventsource": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
@@ -1093,6 +1120,18 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
@@ -1109,6 +1148,26 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
     "node_modules/form-data-encoder": {
@@ -1293,6 +1352,60 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/http-proxy": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/http-proxy-middleware": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.5.tgz",
+      "integrity": "sha512-GLZZm1X38BPY4lkXA01jhwxvDoOkkXqjgVyUzVxiEK4iuRu03PZoYHhHRwxnfhQMDuaxi3vVri0YgSro/1oWqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-proxy": "^1.17.15",
+        "debug": "^4.3.6",
+        "http-proxy": "^1.18.1",
+        "is-glob": "^4.0.3",
+        "is-plain-object": "^5.0.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/http-proxy-middleware/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/http-proxy-middleware/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/http2-wrapper": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
@@ -1369,6 +1482,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-inside-container": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
@@ -1399,6 +1533,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/is-online": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/is-online/-/is-online-10.0.0.tgz",
@@ -1415,6 +1558,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-promise": {
@@ -1511,6 +1663,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
       }
     },
     "node_modules/mime": {
@@ -1722,6 +1887,18 @@
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
     },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/pkce-challenge": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
@@ -1895,6 +2072,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
     },
     "node_modules/resolve-alpn": {
       "version": "1.2.1",
@@ -2166,6 +2349,18 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -2206,7 +2401,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@modelcontextprotocol/sdk": "^1.12.0",
     "dotenv": "^17.2.3",
     "express": "^4.21.0",
+    "http-proxy-middleware": "^3.0.5",
     "is-online": "^10.0.0",
     "open": "^10.1.0",
     "playwright": "^1.49.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,10 @@
 import "dotenv/config";
 import express, { Request, Response } from "express";
+import {
+  createProxyMiddleware,
+  fixRequestBody,
+  responseInterceptor,
+} from "http-proxy-middleware";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { registerWifiTools } from "./tools/wifi.js";
@@ -9,6 +14,21 @@ import { registerCredentialTools } from "./tools/credentials.js";
 import { WpaDaemon } from "./lib/wpa-daemon.js";
 import { DhcpManager } from "./lib/dhcp-manager.js";
 import { WpaConfig } from "./lib/wpa-config.js";
+
+// Intent description surfaced on the proxied Playwright MCP's `initialize`
+// response so agents can tell *this* browser apart from the stock Microsoft
+// Playwright MCP. Shows up in Claude Code's tool metadata as server-level
+// instructions — making it clear when to pick this server over a generic one.
+const WPA_PLAYWRIGHT_INSTRUCTIONS = [
+  "Browser running inside the wpa-mcp container's network namespace.",
+  "",
+  "Use this MCP for any web task AFTER wpa-mcp has joined a Wi-Fi network",
+  "via `wifi_connect` (or any of the WPA tools) — captive portals, portal",
+  "redirects, and web apps only reachable on that WLAN.",
+  "",
+  "Do NOT use this MCP for general browsing on the host's main internet;",
+  "use the stock `playwright` MCP (if registered separately) for that.",
+].join("\n");
 
 const app = express();
 app.use(express.json());
@@ -80,6 +100,79 @@ app.delete("/mcp", (_req: Request, res: Response) => {
     id: null,
   });
 });
+
+// Reverse proxy to the in-container Microsoft Playwright MCP server.
+//
+// Why: browsers launched by that server share this container's network
+// namespace, so they reach captive portals on the WLAN that wifi_connect
+// joined. The upstream is bound to 127.0.0.1:8931 (not exposed externally);
+// this route is the only external entry point.
+//
+// Intent discovery: the `initialize` response is intercepted and its
+// `result.instructions` field is set to WPA_PLAYWRIGHT_INSTRUCTIONS so
+// MCP clients (e.g. Claude Code) surface the "when to pick this server"
+// guidance to the LLM automatically.
+const playwrightMcpPort = process.env.PLAYWRIGHT_MCP_PORT || "8931";
+app.use(
+  "/playwright-mcp",
+  createProxyMiddleware({
+    // NB: use `localhost` (not 127.0.0.1) so the forwarded Host header
+    // matches what Microsoft Playwright MCP binds to — it enforces a
+    // same-origin check on the Host header and rejects anything else.
+    target: `http://localhost:${playwrightMcpPort}`,
+    changeOrigin: true,
+    pathRewrite: () => "/mcp",
+    selfHandleResponse: true,
+    on: {
+      proxyReq: fixRequestBody,
+      proxyRes: responseInterceptor(
+        async (responseBuffer, proxyRes, _req, _res) => {
+          const contentType = String(
+            proxyRes.headers["content-type"] || "",
+          );
+          const body = responseBuffer.toString("utf8");
+
+          // `serverInfo` in result marks an `initialize` JSON-RPC response.
+          const injectIfInitialize = (jsonStr: string): string | null => {
+            try {
+              const obj = JSON.parse(jsonStr);
+              if (obj?.result?.serverInfo) {
+                obj.result.instructions = WPA_PLAYWRIGHT_INSTRUCTIONS;
+                return JSON.stringify(obj);
+              }
+            } catch {
+              /* not JSON — ignore */
+            }
+            return null;
+          };
+
+          // Case 1: plain JSON body (application/json).
+          if (contentType.includes("application/json")) {
+            const rewritten = injectIfInitialize(body);
+            return rewritten ?? responseBuffer;
+          }
+
+          // Case 2: SSE body (text/event-stream) — MCP Streamable HTTP can
+          // return results framed as "event: message\ndata: <json>\n\n".
+          // Rewrite the first `data:` line whose JSON matches the initialize
+          // marker; leave everything else untouched.
+          if (contentType.includes("text/event-stream")) {
+            const rewritten = body.replace(
+              /^data: (.*)$/m,
+              (match, dataJson: string) => {
+                const newJson = injectIfInitialize(dataJson);
+                return newJson ? `data: ${newJson}` : match;
+              },
+            );
+            return rewritten === body ? responseBuffer : rewritten;
+          }
+
+          return responseBuffer;
+        },
+      ),
+    },
+  }),
+);
 
 // Health check endpoint
 app.get("/health", (_req: Request, res: Response) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,71 +108,101 @@ app.delete("/mcp", (_req: Request, res: Response) => {
 // joined. The upstream is bound to 127.0.0.1:8931 (not exposed externally);
 // this route is the only external entry point.
 //
-// Intent discovery: the `initialize` response is intercepted and its
-// `result.instructions` field is set to WPA_PLAYWRIGHT_INSTRUCTIONS so
+// Intent discovery: the `initialize` JSON-RPC response is intercepted and
+// its `result.instructions` field is set to WPA_PLAYWRIGHT_INSTRUCTIONS so
 // MCP clients (e.g. Claude Code) surface the "when to pick this server"
 // guidance to the LLM automatically.
+//
+// Two-proxy shape — intentional. `selfHandleResponse: true` buffers the
+// entire response, which is required to rewrite `initialize` but breaks
+// long-lived SSE streams that MCP uses for tool-call progress and the
+// GET /mcp notification channel. So we dispatch:
+//   - POST whose body.method === "initialize"  → buffered (inject)
+//   - everything else (POST tools/call, GET SSE, DELETE) → streamed
 const playwrightMcpPort = process.env.PLAYWRIGHT_MCP_PORT || "8931";
-app.use(
-  "/playwright-mcp",
-  createProxyMiddleware({
-    // NB: use `localhost` (not 127.0.0.1) so the forwarded Host header
-    // matches what Microsoft Playwright MCP binds to — it enforces a
-    // same-origin check on the Host header and rejects anything else.
-    target: `http://localhost:${playwrightMcpPort}`,
-    changeOrigin: true,
-    pathRewrite: () => "/mcp",
-    selfHandleResponse: true,
-    on: {
-      proxyReq: fixRequestBody,
-      proxyRes: responseInterceptor(
-        async (responseBuffer, proxyRes, _req, _res) => {
-          const contentType = String(
-            proxyRes.headers["content-type"] || "",
-          );
-          const body = responseBuffer.toString("utf8");
+// NB: `localhost` (not 127.0.0.1) so the forwarded Host header matches
+// what Microsoft Playwright MCP binds to — it enforces a same-origin
+// check on the Host header and rejects anything else.
+const playwrightMcpTarget = `http://localhost:${playwrightMcpPort}`;
 
-          // `serverInfo` in result marks an `initialize` JSON-RPC response.
-          const injectIfInitialize = (jsonStr: string): string | null => {
-            try {
-              const obj = JSON.parse(jsonStr);
-              if (obj?.result?.serverInfo) {
-                obj.result.instructions = WPA_PLAYWRIGHT_INSTRUCTIONS;
-                return JSON.stringify(obj);
-              }
-            } catch {
-              /* not JSON — ignore */
+const playwrightInitializeProxy = createProxyMiddleware({
+  target: playwrightMcpTarget,
+  changeOrigin: true,
+  pathRewrite: () => "/mcp",
+  selfHandleResponse: true,
+  on: {
+    proxyReq: fixRequestBody,
+    proxyRes: responseInterceptor(
+      async (responseBuffer, proxyRes, _req, _res) => {
+        const contentType = String(proxyRes.headers["content-type"] || "");
+        const body = responseBuffer.toString("utf8");
+
+        // `serverInfo` in result marks an `initialize` JSON-RPC response.
+        const injectIfInitialize = (jsonStr: string): string | null => {
+          try {
+            const obj = JSON.parse(jsonStr);
+            if (obj?.result?.serverInfo) {
+              obj.result.instructions = WPA_PLAYWRIGHT_INSTRUCTIONS;
+              return JSON.stringify(obj);
             }
-            return null;
-          };
-
-          // Case 1: plain JSON body (application/json).
-          if (contentType.includes("application/json")) {
-            const rewritten = injectIfInitialize(body);
-            return rewritten ?? responseBuffer;
+          } catch {
+            /* not JSON — ignore */
           }
+          return null;
+        };
 
-          // Case 2: SSE body (text/event-stream) — MCP Streamable HTTP can
-          // return results framed as "event: message\ndata: <json>\n\n".
-          // Rewrite the first `data:` line whose JSON matches the initialize
-          // marker; leave everything else untouched.
-          if (contentType.includes("text/event-stream")) {
-            const rewritten = body.replace(
-              /^data: (.*)$/m,
-              (match, dataJson: string) => {
-                const newJson = injectIfInitialize(dataJson);
-                return newJson ? `data: ${newJson}` : match;
-              },
-            );
-            return rewritten === body ? responseBuffer : rewritten;
-          }
+        // Case 1: plain JSON body (application/json).
+        if (contentType.includes("application/json")) {
+          const rewritten = injectIfInitialize(body);
+          return rewritten ?? responseBuffer;
+        }
 
-          return responseBuffer;
-        },
-      ),
-    },
-  }),
-);
+        // Case 2: SSE body (text/event-stream) — MCP Streamable HTTP can
+        // return results framed as "event: message\ndata: <json>\n\n".
+        // Inspect every `data:` line; rewrite only the one whose JSON
+        // matches the initialize marker. The `g` flag is required so
+        // the callback sees each line even when the payload has multiple
+        // events (heartbeats, batched notifications, etc.).
+        if (contentType.includes("text/event-stream")) {
+          const rewritten = body.replace(
+            /^data: (.*)$/gm,
+            (match, dataJson: string) => {
+              const newJson = injectIfInitialize(dataJson);
+              return newJson ? `data: ${newJson}` : match;
+            },
+          );
+          return rewritten === body ? responseBuffer : rewritten;
+        }
+
+        return responseBuffer;
+      },
+    ),
+  },
+});
+
+const playwrightStreamingProxy = createProxyMiddleware({
+  target: playwrightMcpTarget,
+  changeOrigin: true,
+  pathRewrite: () => "/mcp",
+  // No selfHandleResponse — responses stream through naturally.
+  on: {
+    proxyReq: fixRequestBody,
+  },
+});
+
+app.use("/playwright-mcp", (req, res, next) => {
+  // Route to buffered-and-injected proxy only when the JSON-RPC method
+  // is `initialize`. Everything else — tool calls, notification SSE,
+  // session deletes — must stream without buffering.
+  const isInitialize =
+    req.method === "POST" &&
+    typeof req.body === "object" &&
+    req.body !== null &&
+    (req.body as { method?: unknown }).method === "initialize";
+  return isInitialize
+    ? playwrightInitializeProxy(req, res, next)
+    : playwrightStreamingProxy(req, res, next);
+});
 
 // Health check endpoint
 app.get("/health", (_req: Request, res: Response) => {


### PR DESCRIPTION
Closes #41.

## Summary

- Installs `@playwright/mcp` globally in the Docker image; launched as a background subprocess on `127.0.0.1:8931` by `docker/entrypoint.sh`
- Adds a reverse proxy at `/playwright-mcp` in `src/index.ts` that forwards to the internal port — only port 3000 is exposed externally
- The proxy intercepts the `initialize` response (both JSON and SSE bodies) and injects a `result.instructions` string so MCP clients surface a "when to pick this server" description automatically (Level 3 intent discovery)
- No changes to the existing `wpa-mcp` tool surface; `/mcp` endpoint behavior is unchanged

## Why

Browsers launched by the **stock** Microsoft Playwright MCP (running outside this container) route through the host's normal internet and cannot see the captive portal on the WLAN that `wpa-mcp` has joined. Running the Playwright MCP **inside** this container means the browser shares the WiFi network namespace — the only way to reliably drive captive portals end-to-end.

## Architectural notes

- `target` in the proxy is `http://localhost:8931` (not `127.0.0.1`) because `@playwright/mcp` enforces a same-origin Host-header check; binding to `127.0.0.1` but advertising as `localhost` in the Host header fails that check
- `selfHandleResponse: true` buffers responses so the interceptor can rewrite the `initialize` body. This trades streaming efficiency for injection simplicity — fine for normal MCP calls; if a future tool needs streaming this can be made conditional
- Playwright MCP is launched via the direct binary (`playwright-mcp --port ... --host ...`) rather than `npx` because the entrypoint deletes the Docker bridge default route, so `npx`'s registry check fails DNS
- Intent injection matches `result.serverInfo` as the discriminator for the initialize response (no session tracking needed in the proxy)

## Registration

```bash
claude mcp add wpa-mcp         --transport http http://<host>:3000/mcp
claude mcp add wpa-playwright  --transport http http://<host>:3000/playwright-mcp
```

## Test plan

- [x] TypeScript build clean (`npm run build`)
- [x] Docker image builds (`make docker-build`)
- [x] Container starts, phy moves into netns (`sudo make docker-start`)
- [x] wpa-mcp `/mcp` `initialize` + `tools/list` unchanged
- [x] Playwright MCP `/playwright-mcp` `initialize` returns injected `instructions` string
- [x] `Mcp-Session-Id` round-trips through the proxy; `tools/list` with session returns the Playwright tool set
- [x] `@playwright/mcp` process survives after entrypoint; logs to `/tmp/playwright-mcp.log` inside container
- [x] Only port 3000 is published to the host
- [x] Claude Code sees the intent `instructions` on session start (confirmed by registering both MCPs and observing the server metadata surfaced by the client)
- [ ] End-to-end browser interaction through an actual captive portal (deferred — needs a WLAN with a captive portal to run against)

## Files changed

- `docker/Dockerfile` — global install of `@playwright/mcp`
- `docker/entrypoint.sh` — launch `playwright-mcp` binary in background
- `docker/run.sh` — help text only (single port)
- `src/index.ts` — reverse proxy route + response interceptor
- `package.json` / `package-lock.json` — `http-proxy-middleware@^3.0`
- `README.md` — documented both endpoints + registration commands
- `CLAUDE.md` — architecture note for the dual-MCP design