### PR TITLE
Release 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,140 @@
+# Changelog
+
+All notable changes to wpa-mcp are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+---
+
+## [2.0.0] — 2026-04-23
+
+First tagged release. Major-version bump to mark the new dual-MCP public
+contract: the container now exposes **two** MCP endpoints on a single
+port (3000) — `/mcp` (wpa-mcp itself) and `/playwright-mcp` (reverse
+proxy for Microsoft Playwright MCP running inside the container's
+network namespace). See
+[docs/design/13_Dual_MCP_Playwright_Design.md](docs/design/13_Dual_MCP_Playwright_Design.md).
+
+### Added
+
+- **Dual-MCP architecture**: `/playwright-mcp` reverse proxy in front of a
+  containerised `@playwright/mcp@0.0.70` subprocess. The proxied browser
+  shares the container's netns, so it reaches captive portals on the WLAN
+  joined via `wifi_connect` — the only reliable path for WISPr / vendor
+  portal testing. The proxy injects a `result.instructions` string into
+  the `initialize` response so MCP clients surface "when to pick this
+  server" guidance automatically. ([#41], [#43])
+- **systemd daemon**: `sudo make install-systemd` installs a oneshot
+  service that launches the container, moves the WiFi phy into the
+  container's netns, and waits for health on boot. Uninstall with
+  `sudo make uninstall-systemd`. ([#40], [#42])
+- **Persistent credential store**: Docker named volume `wpa-mcp-data`
+  mounted at `/home/node/.config/wpa-mcp` so credentials added at runtime
+  via `credential_store` survive container restarts, image rebuilds, and
+  host reboots. Baked certs under `certs/` are re-imported (idempotent)
+  on every start. ([#40], [#42])
+- **`wifi_hs20_connect`**: Hotspot 2.0 / Passpoint auto-discovery via
+  ANQP queries; reuses `credential_store` for certificates. ([design](docs/design/12_HS20_Design.md))
+- **Permanent-MAC restoration in Docker**: `mac_mode=device` now reads
+  `permaddr` from `ip link show` at daemon start and restores the real
+  hardware MAC before connecting, since `iw phy set netns` causes the
+  kernel to assign a locally-administered MAC. ([#24], [design](docs/design/mac-address-restoration.md))
+- **CI test framework**: YAML-driven test cases under `cicd/tests/` with
+  `build` and `integration` suites, triggered via GitHub Actions
+  `workflow_dispatch`. ([#34])
+- **Functional integration tests**: 13 MCP tool tests exercised over a
+  real Streamable HTTP transport. ([#39])
+- **User stories + traceability**: `docs/user-stories/` with stories for
+  all 22 MCP tools, plus cross-cutting (MAC, Docker netns) stories, each
+  mapped to an acceptance-criteria → test-case matrix. ([#37])
+- **`/prd` and `/user-stories` project skills** for the feature workflow
+  (PRD → user stories → test cases) described in
+  [CLAUDE.md](CLAUDE.md#feature-workflow-prd---user-stories---test-cases).
+  ([#36])
+- **Persistent NetworkManager unmanage**: `sudo make nm-unmanage` writes
+  a drop-in under `/etc/NetworkManager/conf.d/` so the WiFi interface
+  stays unmanaged across reboots. ([Docker Dev Plan §2.1](docs/plans/30_Docker_Dev_Plan.md#21-networkmanager-unmanage))
+- **Container entrypoint**: deletes Docker bridge default route on start
+  (keeping the bridge subnet route) so WiFi becomes the sole default
+  once `wifi_connect` establishes a lease; includes preflight checks and
+  a sanity timer for the Playwright MCP subprocess. ([#42], [#43])
+- **Chromium pre-baked into the image**: `playwright install-deps
+  chromium` + `playwright install chromium` at build time,
+  `PLAYWRIGHT_BROWSERS_PATH=/ms-playwright` — required because the
+  runtime container has no default route (so no on-demand download is
+  possible).
+
+### Changed
+
+- **`wifi_scan` now paginates `bss <id>`** instead of parsing
+  `scan_results`, avoiding truncation in dense RF environments
+  (`scan_results` buffers at ~4 KiB). ([#44], [#45])
+- **Documentation reorganised** into `docs/reference/`, `docs/design/`,
+  `docs/operations/`, `docs/plans/`, `docs/user-stories/` with a new
+  `docs/README.md` master index. ([#36])
+- **README Reference section**: fixed link rot after the docs reorg (all
+  links now point at the correct subfolder).
+- **`docs/reference/00_Architecture.md`**: diagram and endpoint table
+  updated to show the `/playwright-mcp` proxy and the in-container
+  `@playwright/mcp` subprocess.
+
+### Fixed
+
+- `wifi_scan` truncation in dense RF environments (see above). ([#44])
+
+### Internal
+
+- **`http-proxy-middleware@^3.0.5`** added as a dependency for the
+  `/playwright-mcp` reverse proxy.
+- **`@playwright/mcp@0.0.70`** installed globally in the Docker image
+  (pinned; bump deliberately).
+- **TypeScript build** unchanged (`tsc`).
+
+### Notes on public contract
+
+- The only externally-exposed TCP port remains **3000**. The
+  `127.0.0.1:8931` upstream for `@playwright/mcp` is an internal
+  implementation detail and is not part of the public contract.
+- `/mcp` tool surface is unchanged from 1.x — this is additive.
+- `/playwright-mcp` is a **stateful** Streamable HTTP endpoint
+  (`Mcp-Session-Id` round-trip required after `initialize`); `/mcp`
+  remains **stateless**.
+
+---
+
+## [1.0.0] — 2025 (untagged baseline)
+
+Initial feature set prior to the tagging scheme introduced in 2.0.0:
+
+- WiFi tools: `wifi_scan`, `wifi_connect`, `wifi_connect_eap`,
+  `wifi_connect_tls`, `wifi_disconnect`, `wifi_reconnect`, `wifi_status`,
+  `wifi_list_networks`, `wifi_forget`, `wifi_eap_diagnostics`,
+  `wifi_get_debug_logs`.
+- Connectivity tools: `network_ping`, `network_check_internet`,
+  `network_check_captive`, `network_dns_lookup`.
+- Scripted browser tools: `browser_open`, `browser_run_script`,
+  `browser_list_scripts`.
+- Credential tools: `credential_store`, `credential_get`,
+  `credential_list`, `credential_delete`.
+- MAC randomization (`mac_mode`, preassoc, rand_addr_lifetime) across
+  the four connection tools.
+- Docker deployment via `iw phy set netns` for network-namespace
+  isolation of WiFi.
+
+---
+
+[2.0.0]: https://github.com/dogkeeper886/wpa-mcp/releases/tag/v2.0.0
+[1.0.0]: https://github.com/dogkeeper886/wpa-mcp/tree/34522b9
+
+[#24]: https://github.com/dogkeeper886/wpa-mcp/pull/24
+[#34]: https://github.com/dogkeeper886/wpa-mcp/pull/34
+[#36]: https://github.com/dogkeeper886/wpa-mcp/pull/36
+[#37]: https://github.com/dogkeeper886/wpa-mcp/pull/37
+[#39]: https://github.com/dogkeeper886/wpa-mcp/pull/39
+[#40]: https://github.com/dogkeeper886/wpa-mcp/issues/40
+[#41]: https://github.com/dogkeeper886/wpa-mcp/issues/41
+[#42]: https://github.com/dogkeeper886/wpa-mcp/pull/42
+[#43]: https://github.com/dogkeeper886/wpa-mcp/pull/43
+[#44]: https://github.com/dogkeeper886/wpa-mcp/issues/44
+[#45]: https://github.com/dogkeeper886/wpa-mcp/pull/45

--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -1,0 +1,98 @@
+<!--
+This file is the Docker Hub description for dogkeeper886/wpa-mcp.
+Paste the **short description** (below) into the 100-char field on
+Docker Hub, then paste the full body (from the first `#` heading
+onwards) into the Overview tab.
+
+Short description (99 chars):
+  MCP server for Wi-Fi control (WPA/EAP/TLS/HS20) + Playwright MCP inside container's Wi-Fi netns
+-->
+
+# wpa-mcp
+
+MCP (Model Context Protocol) server that lets Claude and other MCP clients drive Wi-Fi on Linux via `wpa_supplicant` — WPA-PSK, WPA2-Enterprise (PEAP/TTLS), EAP-TLS, Hotspot 2.0 / Passpoint, captive portals, MAC randomization.
+
+Source: **https://github.com/dogkeeper886/wpa-mcp**
+
+---
+
+## Tags
+
+| Tag      | Description                              |
+|----------|------------------------------------------|
+| `2.0.0`  | First tagged release                     |
+| `latest` | Tracks the latest stable tag (= `2.0.0`) |
+
+---
+
+## What's inside
+
+- **wpa-mcp** (Node.js / MCP SDK) exposes `/mcp` with Wi-Fi, credential, connectivity, and scripted-browser tools.
+- **Microsoft Playwright MCP** (`@playwright/mcp@0.0.70`) runs as a subprocess at `127.0.0.1:8931` and is reverse-proxied at `/playwright-mcp`. Its browser shares the container's Wi-Fi network namespace, so it can reach captive portals on the WLAN the container has joined — impossible from the host.
+- Chromium is pre-baked into the image (~170 MiB); no runtime downloads are needed.
+- Only port **3000** is exposed externally.
+
+---
+
+## Quick start (requires host setup)
+
+This image needs the host to move the Wi-Fi phy into the container's netns. The easiest path is to clone the repo and use the provided Makefile:
+
+```bash
+git clone https://github.com/dogkeeper886/wpa-mcp
+cd wpa-mcp
+
+# Tell the Makefile to use the Docker Hub image instead of building locally
+echo "WPA_MCP_IMAGE=dogkeeper886/wpa-mcp:2.0.0" >> .env
+
+# Unmanage the Wi-Fi interface from NetworkManager (one-time, persistent)
+sudo make nm-unmanage WIFI_INTERFACE=wlp6s0
+
+# Start the container (moves phy into container netns, waits for health)
+sudo make docker-start
+```
+
+Register the MCP endpoints in Claude Code:
+
+```bash
+claude mcp add wpa-mcp         --transport http http://localhost:3000/mcp
+claude mcp add wpa-playwright  --transport http http://localhost:3000/playwright-mcp
+```
+
+---
+
+## Endpoints
+
+| Path                              | Transport                   | Purpose                                                     |
+|-----------------------------------|-----------------------------|-------------------------------------------------------------|
+| `POST /mcp`                       | Streamable HTTP (stateless) | Wi-Fi / credentials / connectivity / scripted Playwright    |
+| `POST/GET/DELETE /playwright-mcp` | Streamable HTTP (stateful)  | Step-by-step browser control inside the container's netns   |
+| `GET /health`                     | HTTP                        | Health check                                                |
+
+The proxied Playwright MCP injects a server-level `instructions` string into its `initialize` response so agents automatically know when to pick it over a host-side `playwright` MCP.
+
+---
+
+## Requirements on the host
+
+- Linux with Docker
+- `iw` (`sudo dnf install iw` or `sudo apt install iw`)
+- A PCIe or USB Wi-Fi adapter
+- The Wi-Fi interface unmanaged by NetworkManager (the repo's `make nm-unmanage` target handles this)
+
+---
+
+## Docs
+
+- Full README: https://github.com/dogkeeper886/wpa-mcp#readme
+- Architecture: https://github.com/dogkeeper886/wpa-mcp/blob/main/docs/reference/00_Architecture.md
+- Dual-MCP Playwright design: https://github.com/dogkeeper886/wpa-mcp/blob/main/docs/design/13_Dual_MCP_Playwright_Design.md
+- Netns isolation: https://github.com/dogkeeper886/wpa-mcp/blob/main/docs/reference/05_Docker_Netns_Isolation.md
+- Troubleshooting: https://github.com/dogkeeper886/wpa-mcp/blob/main/docs/operations/20_Troubleshooting.md
+- Changelog: https://github.com/dogkeeper886/wpa-mcp/blob/main/CHANGELOG.md
+
+---
+
+## License
+
+MIT

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 MCP (Model Context Protocol) server for WiFi control via wpa_supplicant. Enables Claude and other MCP clients to scan, connect, disconnect, debug, and automate WiFi networks on Linux -- including WPA-PSK, WPA2-Enterprise, EAP-TLS, captive portal handling, and MAC randomization.
 
+**Docker image:** [`dogkeeper886/wpa-mcp`](https://hub.docker.com/r/dogkeeper886/wpa-mcp) — pull `:2.0.0` or `:latest` instead of building locally.
+
 ---
 
 ## Architecture
@@ -63,12 +65,24 @@ sudo make nm-unmanage WIFI_INTERFACE=wlp6s0
 # Creates /etc/NetworkManager/conf.d/99-unmanaged-wlp6s0.conf (persistent)
 ```
 
-### Step 3: Build and start
+### Step 3: Get the image, then start
+
+Either build locally:
 
 ```bash
 make docker-build
 sudo make docker-start
 ```
+
+Or pull the pre-built image from Docker Hub and point the Makefile at it:
+
+```bash
+docker pull dogkeeper886/wpa-mcp:2.0.0
+echo "WPA_MCP_IMAGE=dogkeeper886/wpa-mcp:2.0.0" >> .env
+sudo make docker-start
+```
+
+`WPA_MCP_IMAGE` is read from `.env` by `make docker-start`; default is `wpa-mcp:latest` (the local build).
 
 The start script:
 1. Starts the container with Docker bridge networking (port 3000 forwarded)

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ sudo systemctl stop wpa-mcp
 docker volume rm wpa-mcp-data
 ```
 
-See [docs/05_Structure_and_Flow.md](docs/05_Structure_and_Flow.md) for the full netns architecture and route trace.
+See [docs/reference/05_Docker_Netns_Isolation.md](docs/reference/05_Docker_Netns_Isolation.md) for the full netns architecture and route trace.
 
 ---
 
@@ -343,12 +343,14 @@ Copy `.env.example` to `.env`. Key settings:
 | Document | Description |
 |----------|-------------|
 | [docs/README.md](docs/README.md) | Full documentation index, user flow, and feature table |
-| [docs/00_Architecture.md](docs/00_Architecture.md) | Component architecture and details |
-| [docs/05_Structure_and_Flow.md](docs/05_Structure_and_Flow.md) | Docker netns architecture and route trace |
-| [docs/01_WiFi_Tools.md](docs/01_WiFi_Tools.md) | WiFi tools reference and debug log filters |
-| [docs/03_Browser_Tools.md](docs/03_Browser_Tools.md) | Playwright script format and browser automation |
-| [docs/20_Troubleshooting.md](docs/20_Troubleshooting.md) | Docker and DNS troubleshooting guide |
-| [docs/30_Docker_Dev_Plan.md](docs/30_Docker_Dev_Plan.md) | Docker production-readiness roadmap |
+| [docs/reference/00_Architecture.md](docs/reference/00_Architecture.md) | Component architecture and details |
+| [docs/reference/05_Docker_Netns_Isolation.md](docs/reference/05_Docker_Netns_Isolation.md) | Docker netns architecture and route trace |
+| [docs/reference/01_WiFi_Tools.md](docs/reference/01_WiFi_Tools.md) | WiFi tools reference and debug log filters |
+| [docs/reference/03_Browser_Tools.md](docs/reference/03_Browser_Tools.md) | Scripted runner + proxied Playwright MCP |
+| [docs/design/13_Dual_MCP_Playwright_Design.md](docs/design/13_Dual_MCP_Playwright_Design.md) | Dual-MCP `/playwright-mcp` proxy design |
+| [docs/operations/20_Troubleshooting.md](docs/operations/20_Troubleshooting.md) | Docker and DNS troubleshooting guide |
+| [docs/plans/30_Docker_Dev_Plan.md](docs/plans/30_Docker_Dev_Plan.md) | Docker production-readiness roadmap |
+| [CHANGELOG.md](CHANGELOG.md) | Release history |
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,8 @@
 # wpa-mcp Documentation
 
 **Status:** Complete  
-**Version:** 1.1.0  
-**Updated:** 2026-02-06
+**Version:** 2.0.0  
+**Updated:** 2026-04-23
 
 ---
 
@@ -74,19 +74,31 @@ This documentation provides a comprehensive reference for the wpa-mcp project - 
 
 ## Architecture
 
+One external port (3000) fronts two MCP endpoints: `/mcp` (wpa-mcp itself)
+and `/playwright-mcp` (reverse-proxied Microsoft Playwright MCP running
+inside the container's network namespace so its browser reaches captive
+portals on the WLAN joined via `wifi_connect`). Full design:
+[13_Dual_MCP_Playwright_Design](./design/13_Dual_MCP_Playwright_Design.md).
+
 ```
 ┌─────────────────────────────────────────────────────────────────┐
 │                         MCP Client                              │
 │                  (Claude Desktop / Claude Code)                 │
 └────────────────────────────┬────────────────────────────────────┘
-                             │ HTTP POST /mcp
+                             │ HTTP (single port: 3000)
                              ▼
 ┌─────────────────────────────────────────────────────────────────┐
-│                      src/index.ts                               │
-│              Express + StreamableHTTPServerTransport            │
-├─────────────────────────────────────────────────────────────────┤
-│                      McpServer                                  │
-│              (registers tools from src/tools/*)                 │
+│                      src/index.ts  (Express)                    │
+│                                                                 │
+│  ┌───────────┐  ┌────────────────────┐  ┌───────────────────┐  │
+│  │ POST /mcp │  │ POST/GET/DELETE    │  │     /health       │  │
+│  │ in-proc   │  │  /playwright-mcp   │  │                   │  │
+│  │ McpServer │  │  reverse proxy →   │  │                   │  │
+│  └────┬──────┘  │  @playwright/mcp   │  └───────────────────┘  │
+│       │         │  (loopback :8931)  │                         │
+│       │         └────────────────────┘                         │
+│       ▼                                                        │
+│   tools from src/tools/*                                       │
 └───────┬─────────────────────┬─────────────────────┬─────────────┘
         │                     │                     │
         ▼                     ▼                     ▼
@@ -124,10 +136,11 @@ This documentation provides a comprehensive reference for the wpa-mcp project - 
 | | wifi_connect | Connect to WPA-PSK or open networks | Complete |
 | | wifi_connect_eap | Connect to WPA2-Enterprise (PEAP/TTLS) | Complete |
 | | wifi_connect_tls | Connect using EAP-TLS certificates | Complete |
+| | wifi_hs20_connect | Connect to Hotspot 2.0 / Passpoint network | Complete |
 | | wifi_disconnect | Disconnect from current network | Complete |
 | | wifi_reconnect | Reconnect to saved network | Complete |
 | **Network Management** | | | |
-| | wifi_scan | Scan for available networks | Complete |
+| | wifi_scan | Scan for available networks (paginates BSS ids, no truncation in dense RF) | Complete |
 | | wifi_status | Get current connection status | Complete |
 | | wifi_list_networks | List saved networks | Complete |
 | | wifi_forget | Remove a saved network | Complete |
@@ -141,20 +154,25 @@ This documentation provides a comprehensive reference for the wpa-mcp project - 
 | | network_dns_lookup | Perform DNS lookup | Complete |
 | **Browser Automation** | | | |
 | | browser_open | Open URL in system browser | Complete |
-| | browser_run_script | Execute Playwright script | Complete |
+| | browser_run_script | Execute Playwright script (scripted runner) | Complete |
 | | browser_list_scripts | List available scripts | Complete |
+| | `/playwright-mcp` endpoint | Proxied Microsoft Playwright MCP for step-by-step browser control inside the container's netns (captive portals / WISPr) | Complete |
 | **Credential Management** | | | |
 | | credential_store | Store EAP-TLS certificates | Complete |
 | | credential_get | Retrieve credential metadata | Complete |
 | | credential_list | List all credentials | Complete |
 | | credential_delete | Delete a credential | Complete |
+| | Persistent credential volume | `wpa-mcp-data` named volume survives container restarts | Complete |
+| | Baked cert auto-import | Certs in `certs/` baked into image, re-imported on every start | Complete |
 | **Privacy** | | | |
 | | MAC Randomization | Per-connection MAC address control | Complete |
 | | Pre-assoc MAC | MAC randomization during scanning | Complete |
+| | Permanent MAC restore (Docker) | `mac_mode=device` uses real hardware MAC after `iw phy set netns` | Complete |
 | **Docker** | | | |
 | | Network Namespace Isolation | WiFi phy moved into container netns | Complete |
 | | Entrypoint Route Cleanup | Automatic bridge default route deletion | Complete |
 | | NM Unmanage Automation | Persistent NetworkManager unmanage via Makefile | Complete |
+| | systemd daemon | `sudo make install-systemd` for auto-start on boot | Complete |
 | | Integration Test | Full lifecycle test (18/18 pass) | Complete |
 
 ---
@@ -178,6 +196,7 @@ This documentation provides a comprehensive reference for the wpa-mcp project - 
 | 10 | [EAP-TLS Authentication](./design/10_EAP-TLS_Design.md) | 802.1X certificate authentication design |
 | 11 | [Credential Store](./design/11_Credential_Store_Design.md) | Certificate storage system design |
 | 12 | [HS20 / Passpoint](./design/12_HS20_Design.md) | Hotspot 2.0 auto-discovery design |
+| 13 | [Dual-MCP Playwright](./design/13_Dual_MCP_Playwright_Design.md) | `/playwright-mcp` reverse proxy design |
 | — | [MAC Address Restoration](./design/mac-address-restoration.md) | Docker MAC address decision record |
 
 ### User Stories
@@ -218,16 +237,27 @@ make start
 
 ### 2. Configure MCP Client
 
-Add to Claude Desktop config:
+Both endpoints run on the same external port (3000). Add to Claude
+Desktop config:
 
 ```json
 {
   "mcpServers": {
     "wpa-mcp": {
       "url": "http://localhost:3000/mcp"
+    },
+    "wpa-playwright": {
+      "url": "http://localhost:3000/playwright-mcp"
     }
   }
 }
+```
+
+Or via Claude Code CLI:
+
+```bash
+claude mcp add wpa-mcp         --transport http http://localhost:3000/mcp
+claude mcp add wpa-playwright  --transport http http://localhost:3000/playwright-mcp
 ```
 
 ### 3. Connect to WiFi

--- a/docs/design/13_Dual_MCP_Playwright_Design.md
+++ b/docs/design/13_Dual_MCP_Playwright_Design.md
@@ -1,4 +1,4 @@
-## Dual-MCP Playwright Design
+# Dual-MCP Playwright Design
 
 **Status:** Complete
 **Created:** 2026-04-23

--- a/docs/design/13_Dual_MCP_Playwright_Design.md
+++ b/docs/design/13_Dual_MCP_Playwright_Design.md
@@ -1,0 +1,278 @@
+## Dual-MCP Playwright Design
+
+**Status:** Complete
+**Created:** 2026-04-23
+**Related:** [00_Architecture.md](../reference/00_Architecture.md), [03_Browser_Tools.md](../reference/03_Browser_Tools.md), [05_Docker_Netns_Isolation.md](../reference/05_Docker_Netns_Isolation.md)
+
+---
+
+> **Note:** This is a design document. For usage reference, see [03_Browser_Tools.md](../reference/03_Browser_Tools.md).
+
+---
+
+## Goal
+
+Expose an MCP endpoint — `wpa-playwright` — that gives agents full step-by-step browser control (navigate, click, fill, snapshot, …) from a browser that runs **inside the wpa-mcp container's network namespace**. The browser shares the WLAN joined by `wifi_connect`, which is the only way to reliably drive captive portals, WISPr flows, and portal redirects end-to-end.
+
+The existing `browser_run_script` scripted runner stays; this design **adds** a parallel step-by-step surface by embedding the official [Microsoft Playwright MCP](https://github.com/microsoft/playwright-mcp) server as a subprocess inside the container and reverse-proxying it on the single public port (3000).
+
+---
+
+## Problem Statement
+
+### Why not the stock Playwright MCP?
+
+Running `@playwright/mcp` on the host works for general browsing, but the browser it launches uses the host's routing table. After `wifi_connect` joins a WLAN inside the container, the captive portal only lives on that WLAN — it is invisible from the host. A host-side browser cannot reach it, so authenticating through a portal requires the browser to be inside the container's network namespace.
+
+### Why not just more scripted tools?
+
+`browser_run_script` is good for a known portal flow with pre-written scripts, but poor for exploratory or one-off portals (WISPr variants, unknown vendor portals). Agents need step-by-step primitives — click this element, fill that input, snapshot the DOM — not a full canned script. The Microsoft Playwright MCP already provides those exact primitives; re-implementing them inside `wpa-mcp` would be duplication.
+
+### Why one port?
+
+The container exposes exactly one TCP port (3000) to the host. Exposing a second port for the Playwright MCP would require another Docker port mapping and firewall allowance, and would make the MCP client configuration more brittle. A reverse proxy on a separate path keeps the external contract stable.
+
+---
+
+## User Flow
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│          User joins WLAN behind captive portal                  │
+│          wifi_connect → IP obtained, no internet                │
+│          network_check_captive → redirect_url detected          │
+└────────────────────────────────┬────────────────────────────────┘
+                                 │
+                                 ▼
+┌─────────────────────────────────────────────────────────────────┐
+│   Agent picks wpa-playwright MCP (based on its `instructions`)  │
+└────────────────────────────────┬────────────────────────────────┘
+                                 │
+                                 ▼
+┌─────────────────────────────────────────────────────────────────┐
+│   browser_navigate(url)                                         │
+│   browser_snapshot()                                            │
+│   browser_click(ref)                                            │
+│   browser_fill_form({ ... })                                    │
+│   ... (iterate until portal accepts)                            │
+└────────────────────────────────┬────────────────────────────────┘
+                                 │
+                                 ▼
+┌─────────────────────────────────────────────────────────────────┐
+│   network_check_internet → captive portal cleared               │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Architecture
+
+### Public surface (one external port)
+
+```
+  ┌─────────────────────────────────────────────────────────┐
+  │  HOST                                                    │
+  │                                                          │
+  │         MCP Client (Claude Code / Desktop)              │
+  │                         │                                │
+  │                         │   HTTP                         │
+  │                         │   POST/GET/DELETE              │
+  │                         ▼                                │
+  │                  host:3000                               │
+  └─────────────────────────┼────────────────────────────────┘
+                            │  (Docker port forward,
+                            │   only port exposed)
+  ┌─────────────────────────┼────────────────────────────────┐
+  │  CONTAINER (wpa-mcp)    ▼                                 │
+  │                                                           │
+  │                 express on :3000                          │
+  │                   │                                       │
+  │    ┌──────────────┼──────────────┐                        │
+  │    ▼              ▼              ▼                        │
+  │  /mcp       /playwright-mcp   /health                     │
+  │  (in-proc)  (reverse proxy)                               │
+  │                   │                                       │
+  │                   │  http://localhost:8931/mcp            │
+  │                   ▼                                       │
+  │            @playwright/mcp subprocess                     │
+  │            (loopback-only, not exposed)                   │
+  │                   │                                       │
+  │                   ▼                                       │
+  │              headless Chromium                            │
+  │                   │                                       │
+  │                   │  uses container's netns               │
+  │                   ▼                                       │
+  │              wlan0 → joined WLAN                          │
+  └───────────────────────────────────────────────────────────┘
+```
+
+### Endpoint mapping
+
+| External path            | Transport                  | Served by                                       | Session model                   |
+|--------------------------|-----------------------------|-------------------------------------------------|---------------------------------|
+| `POST /mcp`              | Streamable HTTP (stateless) | `wpa-mcp` in-process                            | Stateless                       |
+| `POST /playwright-mcp`   | Streamable HTTP (stateful)  | Reverse proxy → `@playwright/mcp` on `:8931`    | `Mcp-Session-Id` round-tripped  |
+| `GET /playwright-mcp`    | SSE notification channel    | Reverse proxy (streamed)                        | Requires session id             |
+| `DELETE /playwright-mcp` | Session close               | Reverse proxy (streamed)                        | Requires session id             |
+| `GET /health`            | HTTP                        | `wpa-mcp` in-process                            | —                               |
+
+`127.0.0.1:8931` is **internal implementation only** — never exposed externally and not part of the public contract. Its port is overridable via `PLAYWRIGHT_MCP_PORT` but there is no reason to change it.
+
+---
+
+## Design Decisions
+
+### 1. Subprocess + reverse proxy (vs. embedding the MCP as a library)
+
+**Choice:** run `@playwright/mcp` as a separate process launched by the container entrypoint; reverse-proxy it from the Node app.
+
+**Rationale:**
+- **Separation of concerns** — the Microsoft MCP has its own lifecycle, browser management, and transport. Wrapping it as a subprocess means `wpa-mcp` does not have to track upstream API changes.
+- **Fault isolation** — a browser crash inside the Playwright MCP does not crash `wpa-mcp`; the Node server can keep serving `wifi_*` / `network_*` tools.
+- **Consistency** — same deploy shape as upstream's own Docker example; easy to diff against their guidance.
+
+Tradeoff: one extra process + a small amount of proxy code in `src/index.ts`.
+
+### 2. Two proxy instances, dispatched by method (vs. one proxy)
+
+The proxy layer has **two** `http-proxy-middleware` instances and dispatches per request:
+
+| Instance                       | `selfHandleResponse` | Purpose                                                                     |
+|--------------------------------|----------------------|-----------------------------------------------------------------------------|
+| `playwrightInitializeProxy`    | `true`               | Buffers full response so `initialize` body can be rewritten with instructions |
+| `playwrightStreamingProxy`     | `false`              | Streams everything else — tool-call results, SSE notifications, session delete |
+
+Dispatch (`src/index.ts`):
+
+```ts
+const isInitialize =
+  req.method === "POST" &&
+  typeof req.body === "object" &&
+  req.body !== null &&
+  (req.body as { method?: unknown }).method === "initialize";
+return isInitialize
+  ? playwrightInitializeProxy(req, res, next)
+  : playwrightStreamingProxy(req, res, next);
+```
+
+**Why two, not one:**
+`selfHandleResponse: true` buffers the entire response body, which is required to rewrite the `initialize` response. But MCP uses long-lived SSE streams for tool progress and the `GET /mcp` notification channel, and buffering would deadlock those. Splitting by method keeps injection simple without breaking streaming.
+
+### 3. `http://localhost:8931` (not `127.0.0.1:8931`) as the proxy target
+
+`@playwright/mcp` enforces a same-origin `Host` header check. The proxy forwards the Host as whatever `changeOrigin: true` sets it to; binding the upstream at `127.0.0.1` but announcing `localhost` in the Host header fails that check. The simplest fix is to target `http://localhost:...` so the forwarded Host matches. Node's DNS resolver maps `localhost` → `127.0.0.1` with no network cost.
+
+### 4. Intent discovery via the `initialize` response
+
+MCP defines an optional `result.instructions` string on `initialize` responses. When present, clients like Claude Code surface it as server-level guidance to the LLM. The proxy sets this field on every initialize response so agents automatically see a "when to pick this server" description — without the user editing their MCP config or relying on the upstream default (which has none).
+
+Implementation detail — the injection runs on two content types:
+
+| Content type            | Strategy                                                                                    |
+|-------------------------|---------------------------------------------------------------------------------------------|
+| `application/json`      | `JSON.parse` the body; if `result.serverInfo` is present, set `result.instructions` and re-serialize. |
+| `text/event-stream`     | Scan each `data: <json>` line with the `/^data: (.*)$/gm` regex; rewrite only the line whose JSON matches the initialize marker. |
+
+The SSE path **requires** the `g` flag so the replacer callback sees every `data:` line — a single event stream can contain heartbeats and batched notifications interleaved with the initialize response.
+
+Marker: `obj?.result?.serverInfo`. This is the only JSON-RPC response where that field is present, so it's a safe discriminator without tracking session state in the proxy.
+
+### 5. Launch the binary directly, not via `npx`
+
+The container entrypoint deletes the Docker bridge default route before the Node server starts, so the container has **no default route** until `wifi_connect` establishes one. `npx @playwright/mcp` performs a registry check at launch time and hangs on DNS. Using the installed binary (`playwright-mcp --port ... --host ...`) skips that check.
+
+### 6. Pinned `@playwright/mcp@0.0.70`
+
+Pre-release upstream; pin the exact version in the Dockerfile so image builds are reproducible. Bump intentionally as a separate commit after exercising the new version.
+
+### 7. Pre-bake Chromium at build time
+
+Runtime downloads are impossible for the same reason as (5) — no default route. The Dockerfile runs `playwright install-deps chromium` and `playwright install chromium` at build time, pinning the browser cache to `PLAYWRIGHT_BROWSERS_PATH=/ms-playwright` so both root (build-time install) and the `node` user (runtime) read from the same location. Adds ~170 MiB to the image; non-negotiable given the network constraint.
+
+### 8. `--allow-unrestricted-file-access` and pinned `--output-dir`
+
+Two constraints interact here:
+- Claude Code sends the **client's** working directory as a file-access root on initialize (e.g. `/home/jack/something`). That path does not exist in the container.
+- `@playwright/mcp` defaults to writing trace/screenshot artifacts under `<client.cwd>/.playwright-mcp`, so `mkdir -p` fails with `EACCES` as the `node` user.
+
+Fix: launch with `--allow-unrestricted-file-access` (accept any root) and `--output-dir /tmp/playwright-mcp-output` (always writable). Both apply only inside the container and have no effect on the host.
+
+### 9. No changes to the existing `/mcp` tool surface
+
+`wpa-mcp`'s own tools are unchanged. The dual-MCP split is purely additive: the scripted runner (`browser_run_script`) still serves pre-written automation flows; the new surface serves exploratory/unknown portals.
+
+---
+
+## Intent String
+
+The exact text injected into `initialize.result.instructions` (from `src/index.ts`):
+
+```
+Browser running inside the wpa-mcp container's network namespace.
+
+Use this MCP for any web task AFTER wpa-mcp has joined a Wi-Fi network
+via `wifi_connect` (or any of the WPA tools) — captive portals, portal
+redirects, and web apps only reachable on that WLAN.
+
+Do NOT use this MCP for general browsing on the host's main internet;
+use the stock `playwright` MCP (if registered separately) for that.
+```
+
+This is the text a Claude Code client sees as server-level guidance when it registers the endpoint.
+
+---
+
+## Registration
+
+```bash
+# Host-reachable hostname/port, one port for both endpoints
+claude mcp add wpa-mcp         --transport http http://<HOST>:3000/mcp
+claude mcp add wpa-playwright  --transport http http://<HOST>:3000/playwright-mcp
+```
+
+For general-purpose browsing (host internet, not container WLAN), register the stock Microsoft Playwright MCP separately — it complements `wpa-playwright`, does not replace it.
+
+---
+
+## Operational Notes
+
+| Aspect                    | Detail                                                                                   |
+|---------------------------|------------------------------------------------------------------------------------------|
+| Playwright MCP log        | `/tmp/playwright-mcp.log` inside the container                                           |
+| Bind address              | `127.0.0.1:8931` (loopback only; not exposed via Docker)                                 |
+| Startup sanity check      | Entrypoint waits up to 5 s for the socket to bind; logs a clear error if it doesn't     |
+| Port override             | `PLAYWRIGHT_MCP_PORT` environment variable (both entrypoint and Node proxy read it)     |
+| Artifact output dir       | `/tmp/playwright-mcp-output` (ephemeral, lost on container restart)                      |
+| Chromium cache            | `/ms-playwright` (baked into image)                                                     |
+| Browser sandbox           | Disabled (`--no-sandbox`); Chromium's setuid sandbox needs caps the container omits     |
+
+---
+
+## Files Touched
+
+| File                          | Role                                                           |
+|-------------------------------|----------------------------------------------------------------|
+| `src/index.ts`                | Two reverse-proxy instances + dispatcher + intent injection    |
+| `docker/entrypoint.sh`        | Launches `playwright-mcp` in the background + sanity check     |
+| `docker/Dockerfile`           | Installs `@playwright/mcp@0.0.70`, pre-bakes Chromium + deps   |
+| `package.json` / lockfile     | `http-proxy-middleware@^3.0.5`                                 |
+| `CLAUDE.md` / `README.md`     | Documents the dual endpoint and registration                   |
+
+---
+
+## Non-Goals
+
+- Shared browser session across `/mcp` and `/playwright-mcp`. They are independent transports; sharing state would pull the scripted runner's browser lifecycle into the subprocess, which conflicts with fault isolation.
+- TLS termination at the proxy. The container's transport is plain HTTP on localhost/bridge; if TLS is needed, put it in front of Docker (reverse proxy on the host).
+- Persistence of Playwright MCP session state across container restarts. Sessions are ephemeral by design; agents re-initialize.
+
+---
+
+## References
+
+- [Microsoft Playwright MCP](https://github.com/microsoft/playwright-mcp)
+- [http-proxy-middleware responseInterceptor](https://github.com/chimurai/http-proxy-middleware)
+- [MCP Streamable HTTP transport](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http)
+- [00_Architecture.md](../reference/00_Architecture.md) — overall architecture
+- [03_Browser_Tools.md](../reference/03_Browser_Tools.md) — browser tool reference
+- [05_Docker_Netns_Isolation.md](../reference/05_Docker_Netns_Isolation.md) — why the browser must live in the container's netns

--- a/docs/reference/00_Architecture.md
+++ b/docs/reference/00_Architecture.md
@@ -1,7 +1,7 @@
 # Architecture
 
 **Status:** Complete  
-**Updated:** 2026-01-14
+**Updated:** 2026-04-23
 
 ---
 
@@ -13,6 +13,17 @@ This document describes the system architecture of wpa-mcp, including component 
 
 ## System Overview
 
+The container exposes **one** external port (3000) that fronts two MCP
+endpoints: the in-process `wpa-mcp` server (WiFi / credentials / connectivity
+/ scripted browser) and a reverse proxy in front of the
+[Microsoft Playwright MCP](https://github.com/microsoft/playwright-mcp)
+running as a subprocess on `127.0.0.1:8931`. Both endpoints share the
+container's network namespace, so the Playwright browser reaches captive
+portals on the WLAN that `wifi_connect` joined.
+
+See [13_Dual_MCP_Playwright_Design.md](../design/13_Dual_MCP_Playwright_Design.md)
+for the design decisions behind the proxy.
+
 ```
 ┌─────────────────────────────────────────────────────────────────┐
 │                    MCP Client Layer                             │
@@ -23,55 +34,50 @@ This document describes the system architecture of wpa-mcp, including component 
 │  - Manages conversation context                                 │
 └────────────────────────────┬────────────────────────────────────┘
                              │
-                             │ HTTP POST /mcp (JSON-RPC)
+                             │  HTTP (JSON-RPC, Streamable HTTP)
+                             │  single external port: 3000
                              ▼
 ┌─────────────────────────────────────────────────────────────────┐
 │                    Transport Layer                              │
-│              src/index.ts                                       │
+│              src/index.ts  (Express, port 3000)                 │
 │                                                                 │
-│  ┌─────────────────┐    ┌─────────────────────────────────┐    │
-│  │  Express Server │───►│ StreamableHTTPServerTransport   │    │
-│  │  Port: 3000     │    │ Handles MCP protocol framing    │    │
-│  └─────────────────┘    └─────────────────────────────────┘    │
-│                                                                 │
-│  Endpoints:                                                     │
-│  - POST /mcp      MCP protocol                                  │
-│  - GET  /health   Health check                                  │
-└────────────────────────────┬────────────────────────────────────┘
-                             │
-                             ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                    MCP Server Layer                             │
-│              @modelcontextprotocol/sdk                          │
-│                                                                 │
-│  - Registers tools with Zod schemas                             │
-│  - Validates incoming parameters                                │
-│  - Routes requests to handlers                                  │
-│  - Formats responses                                            │
-└────────────────────────────┬────────────────────────────────────┘
-                             │
-        ┌────────────────────┼────────────────────┐
-        ▼                    ▼                    ▼
-┌───────────────┐    ┌───────────────┐    ┌───────────────┐
-│  WiFi Tools   │    │Browser Tools  │    │ Connectivity  │
-│               │    │               │    │    Tools      │
-│ wifi.ts       │    │ browser.ts    │    │connectivity.ts│
-│ credentials.ts│    │               │    │               │
-└───────┬───────┘    └───────┬───────┘    └───────┬───────┘
-        │                    │                    │
-        ▼                    ▼                    ▼
-┌───────────────┐    ┌───────────────┐    ┌───────────────┐
-│  WiFi Libs    │    │ Playwright    │    │ Network Check │
-│               │    │   Runner      │    │               │
-│ wpa-cli.ts    │    │               │    │ network-      │
-│ wpa-daemon.ts │    │ playwright-   │    │   check.ts    │
-│ dhcp-manager  │    │   runner.ts   │    │               │
-│ mac-utils.ts  │    │               │    │               │
-│ credential-   │    │               │    │               │
-│   store.ts    │    │               │    │               │
-└───────┬───────┘    └───────┬───────┘    └───────┬───────┘
-        │                    │                    │
-        ▼                    ▼                    ▼
+│  ┌──────────────┐   ┌───────────────────┐   ┌──────────────┐   │
+│  │  POST /mcp   │   │ POST/GET/DELETE   │   │ GET /health  │   │
+│  │  (stateless) │   │  /playwright-mcp  │   │              │   │
+│  └──────┬───────┘   │  (stateful)       │   └──────────────┘   │
+│         │           └────────┬──────────┘                       │
+│         │                    │ reverse proxy                    │
+│         │                    │ (see design doc 13)              │
+│         │                    ▼                                  │
+│         │         ┌────────────────────┐                        │
+│         │         │ @playwright/mcp    │                        │
+│         │         │ subprocess         │                        │
+│         │         │ 127.0.0.1:8931     │  (internal only)       │
+│         │         └─────────┬──────────┘                        │
+│         │                   │                                   │
+│         ▼                   ▼                                   │
+└─────────┼─────────────────────────────────────────────────────┬─┘
+          │                                                     │
+          ▼                                                     │
+┌─────────────────────────────────────────────────────────────┐ │
+│                    MCP Server Layer                         │ │
+│              @modelcontextprotocol/sdk                      │ │
+│                                                             │ │
+│  - Registers tools with Zod schemas                         │ │
+│  - Validates incoming parameters                            │ │
+│  - Routes requests to handlers                              │ │
+└────────────────────────────┬────────────────────────────────┘ │
+                             │                                  │
+        ┌────────────────────┼────────────────────┐             │
+        ▼                    ▼                    ▼             │
+┌───────────────┐    ┌───────────────┐    ┌───────────────┐     │
+│  WiFi Tools   │    │Browser Tools  │    │ Connectivity  │     │
+│               │    │               │    │    Tools      │     │
+│ wifi.ts       │    │ browser.ts    │    │connectivity.ts│     │
+│ credentials.ts│    │               │    │               │     │
+└───────┬───────┘    └───────┬───────┘    └───────┬───────┘     │
+        │                    │                    │             │
+        ▼                    ▼                    ▼             ▼
 ┌─────────────────────────────────────────────────────────────────┐
 │                    System Layer                                 │
 │                                                                 │
@@ -85,6 +91,14 @@ This document describes the system architecture of wpa-mcp, including component 
 └─────────────────────────────────────────────────────────────────┘
 ```
 
+### Endpoint summary
+
+| Path                     | Transport                  | Served by                            | Session      |
+|--------------------------|-----------------------------|--------------------------------------|--------------|
+| `POST /mcp`              | Streamable HTTP, stateless  | `wpa-mcp` in-process                 | —            |
+| `/playwright-mcp`        | Streamable HTTP, stateful   | Reverse proxy → `@playwright/mcp`    | `Mcp-Session-Id` |
+| `GET /health`            | HTTP                        | `wpa-mcp` in-process                 | —            |
+
 ---
 
 ## Component Details
@@ -94,16 +108,24 @@ This document describes the system architecture of wpa-mcp, including component 
 Main server initialization and lifecycle management.
 
 **Responsibilities:**
-- Create Express HTTP server
+- Create Express HTTP server on the single external port (3000)
 - Initialize MCP server with transport
 - Create WpaDaemon instance (managed wpa_supplicant)
 - Create DhcpManager instance
 - Register all tools from src/tools/*
+- Mount the `/playwright-mcp` reverse proxy (two instances: a buffered
+  proxy that injects intent-discovery `instructions` into the `initialize`
+  response, and a streaming proxy for everything else — see
+  [13_Dual_MCP_Playwright_Design.md](../design/13_Dual_MCP_Playwright_Design.md))
 - Handle graceful shutdown (SIGTERM, SIGINT)
+
+The `@playwright/mcp` subprocess itself is launched by
+`docker/entrypoint.sh` on `127.0.0.1:8931` before Node starts — the Node
+server only proxies to it.
 
 **Key Objects:**
 ```typescript
-const server = new Server({ name: "wpa-mcp", version: "1.0.0" });
+const server = new Server({ name: "wpa-mcp", version: "2.0.0" });
 const wpaDaemon = new WpaDaemon(config.interface);
 const dhcpManager = new DhcpManager(config.interface);
 const wpa = new WpaCli(config.interface);
@@ -469,11 +491,16 @@ WPA_MCP_SCRIPTS_DIR=~/.config/wpa-mcp/scripts
 |---------|---------|---------|
 | @modelcontextprotocol/sdk | ^1.12.0 | MCP protocol |
 | express | ^4.21.0 | HTTP server |
+| http-proxy-middleware | ^3.0.5 | Reverse proxy for `/playwright-mcp` |
 | zod | ^3.24.0 | Input validation |
-| playwright | ^1.49.0 | Browser automation |
+| playwright | ^1.49.0 | Browser automation (scripted runner) |
 | dotenv | ^17.2.3 | Environment config |
 | is-online | ^10.0.0 | Internet check |
 | open | ^10.1.0 | Browser opening |
+
+The container also runs `@playwright/mcp` as a subprocess (installed
+globally in the Docker image, pinned version). That is not a Node
+dependency of this project.
 
 ---
 
@@ -482,3 +509,5 @@ WPA_MCP_SCRIPTS_DIR=~/.config/wpa-mcp/scripts
 - [01_WiFi_Tools.md](./01_WiFi_Tools.md) - WiFi tool reference
 - [02_Connectivity_Tools.md](./02_Connectivity_Tools.md) - Network diagnostics
 - [03_Browser_Tools.md](./03_Browser_Tools.md) - Browser automation
+- [05_Docker_Netns_Isolation.md](./05_Docker_Netns_Isolation.md) - Why the container has its own netns
+- [13_Dual_MCP_Playwright_Design.md](../design/13_Dual_MCP_Playwright_Design.md) - Design of the `/playwright-mcp` reverse proxy

--- a/docs/reference/03_Browser_Tools.md
+++ b/docs/reference/03_Browser_Tools.md
@@ -1,7 +1,7 @@
 # Browser Tools
 
 **Status:** Complete  
-**Updated:** 2026-01-14
+**Updated:** 2026-04-23
 
 ---
 
@@ -11,11 +11,39 @@ This document provides a complete reference for browser automation tools, primar
 
 ---
 
-## Tools Overview
+## Two Complementary Browser Surfaces
+
+wpa-mcp exposes browser control through two MCP endpoints on the same
+external port (3000). Pick by task, not by preference — they solve
+different problems.
+
+| Surface                | Path                | Best for                                                                                 |
+|------------------------|---------------------|------------------------------------------------------------------------------------------|
+| Scripted runner        | `/mcp`              | **Known** portal flows with pre-written scripts checked into `~/.config/wpa-mcp/scripts/`. Fire-and-forget. |
+| Proxied `wpa-playwright` | `/playwright-mcp`   | **Unknown / exploratory** portals (WISPr, vendor-specific, one-off). Step-by-step primitives: navigate, click, fill, snapshot. |
+
+The proxied surface is the Microsoft [`@playwright/mcp`](https://github.com/microsoft/playwright-mcp)
+server running as a subprocess inside this container, so the browser
+it launches shares the container's network namespace — the only way
+to reach captive portals on the WLAN joined via `wifi_connect`. See
+[13_Dual_MCP_Playwright_Design.md](../design/13_Dual_MCP_Playwright_Design.md)
+for the design and [00_Architecture.md](./00_Architecture.md#endpoint-summary)
+for the endpoint summary. For general browsing on the host's internet,
+register the stock `@playwright/mcp` separately.
+
+This document covers the scripted runner (`browser_*` tools under
+`/mcp`). For the step-by-step tools exposed by `/playwright-mcp`
+(`browser_navigate`, `browser_click`, `browser_fill_form`,
+`browser_snapshot`, ...), consult the
+[Microsoft Playwright MCP documentation](https://github.com/microsoft/playwright-mcp).
+
+---
+
+## Scripted Tools Overview
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│                     Browser Tools                               │
+│            Scripted Browser Tools (served on /mcp)              │
 ├─────────────────────────────────────────────────────────────────┤
 │                                                                 │
 │  browser_open           Open URL in system browser              │
@@ -474,3 +502,4 @@ export default async function(page, variables) {
 
 - [00_Architecture.md](./00_Architecture.md) - System architecture
 - [02_Connectivity_Tools.md](./02_Connectivity_Tools.md) - Captive portal detection
+- [13_Dual_MCP_Playwright_Design.md](../design/13_Dual_MCP_Playwright_Design.md) - Design of the proxied `/playwright-mcp` endpoint

--- a/docs/user-stories/42_Browser_Stories.md
+++ b/docs/user-stories/42_Browser_Stories.md
@@ -2,7 +2,8 @@
 
 **Status:** Draft
 **Created:** 2026-04-10
-**Source:** [src/tools/browser.ts](../../src/tools/browser.ts) | [03_Browser_Tools](../reference/03_Browser_Tools.md)
+**Updated:** 2026-04-23
+**Source:** [src/tools/browser.ts](../../src/tools/browser.ts) | [src/index.ts](../../src/index.ts) | [03_Browser_Tools](../reference/03_Browser_Tools.md) | [13_Dual_MCP_Playwright_Design](../design/13_Dual_MCP_Playwright_Design.md)
 
 ---
 
@@ -91,6 +92,45 @@ As a user, I want to list available Playwright scripts so that I know which auto
 
 ---
 
+## US-BROW-004: Step-by-Step Browser Control Inside the Container's Netns
+
+**Endpoint:** `/playwright-mcp` | **Ref:** [03_Browser_Tools - Two Surfaces](../reference/03_Browser_Tools.md#two-complementary-browser-surfaces) | [13_Dual_MCP_Playwright_Design](../design/13_Dual_MCP_Playwright_Design.md)
+
+As a user driving an unknown captive portal (e.g. WISPr, vendor-specific hotel portal), I want step-by-step browser primitives from a browser that shares the container's WLAN network namespace, so that I can authenticate through portals that are unreachable from the host.
+
+### Acceptance Criteria
+
+1. `wpa-playwright` MCP endpoint is reachable at `/playwright-mcp` on the same external port as `/mcp` (3000)
+2. `initialize` on `/playwright-mcp` returns a `result.instructions` string so MCP clients surface "when to pick this server" guidance to the agent without user configuration
+3. The intent string explicitly tells the agent to pick this server **after** `wifi_connect` for captive-portal / WLAN-only web tasks, and **not** for general host-internet browsing
+4. Subsequent tool calls (`tools/list`, `tools/call`) round-trip the `Mcp-Session-Id` header returned by `initialize`
+5. SSE notification channel (`GET /playwright-mcp`) streams without being buffered by the proxy
+6. Browser launched by the proxied MCP reaches URLs on the WLAN joined via `wifi_connect` (captive portals, intranet-only hosts)
+7. Browser cannot accidentally bypass the container netns (e.g., cannot reach host-only internet routes)
+8. `@playwright/mcp` subprocess binds only to `127.0.0.1:8931`; no second external port is exposed
+9. If the `@playwright/mcp` subprocess fails to bind at container startup, the entrypoint logs a clear error pointing at `/tmp/playwright-mcp.log`
+10. Intent-injection works for both JSON (`application/json`) and SSE (`text/event-stream`) response bodies
+
+### Test Mapping
+
+| AC# | Test Case | Status |
+|-----|-----------|--------|
+| 1 | — | No test |
+| 2 | — | No test |
+| 3 | — | No test |
+| 4 | — | No test |
+| 5 | — | No test |
+| 6 | — | No test |
+| 7 | — | No test |
+| 8 | — | No test |
+| 9 | — | No test |
+| 10 | — | No test |
+
+### Tags
+`browser`, `playwright-mcp`, `captive-portal`, `wispr`, `netns`, `proxy`
+
+---
+
 ## Traceability Matrix
 
 | Story | AC | Test Case | Status |
@@ -98,5 +138,6 @@ As a user, I want to list available Playwright scripts so that I know which auto
 | US-BROW-001 | AC1-3 | — | No test |
 | US-BROW-002 | AC1-7 | — | No test |
 | US-BROW-003 | AC1-4 | — | No test |
+| US-BROW-004 | AC1-10 | — | No test |
 
-**Coverage:** 0/14 ACs have test coverage.
+**Coverage:** 0/24 ACs have test coverage.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wpa-mcp",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wpa-mcp",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wpa-mcp",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "MCP Server for WiFi control via wpa_supplicant",
   "type": "module",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,7 @@ const dhcpManager = new DhcpManager();
 // Create MCP server
 const mcpServer = new McpServer({
   name: "wpa-mcp",
-  version: "1.0.0",
+  version: "2.0.0",
 });
 
 // Register all tools
@@ -206,7 +206,7 @@ app.use("/playwright-mcp", (req, res, next) => {
 
 // Health check endpoint
 app.get("/health", (_req: Request, res: Response) => {
-  res.json({ status: "ok", server: "wpa-mcp", version: "1.0.0" });
+  res.json({ status: "ok", server: "wpa-mcp", version: "2.0.0" });
 });
 
 // Graceful shutdown


### PR DESCRIPTION
First tagged release. Marks the dual-MCP public contract —
the single external port (3000) now fronts both `/mcp`
(wpa-mcp) and `/playwright-mcp` (reverse proxy for the
in-container Microsoft Playwright MCP, #41/#43).

## What's in the release

Design + docs catching up to code shipped in PRs #22, #24, #31,
#34, #36, #37, #39, #42, #43, #45.

- **New:** `docs/design/13_Dual_MCP_Playwright_Design.md` —
  goals, architecture, two-proxy dispatch (buffered `initialize`
  + streaming tool-calls/SSE), intent-injection into the
  `initialize` response, the `localhost:8931` Host-header
  quirk, pinned `@playwright/mcp@0.0.70`, pre-baked Chromium,
  direct-binary (not `npx`) rationale.
- **Updated:** `docs/reference/00_Architecture.md` — diagram
  now shows `/playwright-mcp` proxy + `@playwright/mcp`
  subprocess, added `http-proxy-middleware` to deps table,
  added design doc 13 to related docs.
- **Updated:** `docs/reference/03_Browser_Tools.md` — two
  complementary browser surfaces section distinguishing the
  scripted runner (`/mcp`) from the proxied step-by-step
  (`/playwright-mcp`); points at design doc 13.
- **New:** `US-BROW-004` in `docs/user-stories/42_Browser_Stories.md`
  with 10 ACs covering the proxied endpoint, intent-injection,
  session round-tripping, SSE streaming, and startup sanity.
- **Fixed:** 6 broken Reference links in `README.md` that
  predated the `docs/reference/`, `docs/operations/`,
  `docs/plans/` reorg.
- **Updated:** `docs/README.md` — features table now lists
  HS20, proxied Playwright MCP, systemd daemon, persistent
  credential store, permanent-MAC restore. Version header
  bumped to 2.0.0.
- **New:** `CHANGELOG.md` — 1.0.0 → 2.0.0.
- **Bumped:** `package.json`, `package-lock.json`,
  `src/index.ts` (McpServer version + `/health` response).

## Non-changes

- `/mcp` tool surface is unchanged from 1.x — this release
  is additive on the public contract.
- Only port **3000** is exposed externally; `127.0.0.1:8931`
  (the `@playwright/mcp` upstream) remains an internal
  implementation detail.

## Test plan

- [x] `npm run build` clean
- [x] `npx tsx cicd/tests/src/cli.ts run --suite build --no-llm` → 2/2 pass (TC-BUILD-001 + TC-BUILD-002 Docker build)
- [ ] After merge: tag `v2.0.0`, `gh release create v2.0.0 --notes-from-tag` (or paste the CHANGELOG section)
- [ ] Optional: run `--suite integration --no-llm` on a host with Wi-Fi hardware

🤖 Generated with [Claude Code](https://claude.com/claude-code)