### PR TITLE
feat: configurable browser locale and timezone (#47)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,15 @@ WPA_DEBUG_LEVEL=2
 # Playwright scripts directory
 # WPA_MCP_SCRIPTS_DIR=~/.config/wpa-mcp/scripts
 
+# Browser locale and timezone for the in-container headless Chromium spawned by
+# playwright-mcp. Used for i18n captive-portal testing (verifying a portal popup
+# or its triggered emails render in a visitor's expected language). Both are
+# read at container start; changing them requires `make docker-restart`. Only
+# the browser is affected — container shell LANG / date / log timestamps are
+# unchanged. See docs/design/14_Browser_Locale_Timezone_Design.md.
+# WPA_MCP_BROWSER_LANG=pt-PT
+# WPA_MCP_BROWSER_TZ=Europe/Lisbon
+
 # Deployment settings (used by Makefile)
 # REMOTE_HOST=user@192.168.1.100
 # REMOTE_DIR=~/wpa-mcp

--- a/README.md
+++ b/README.md
@@ -325,6 +325,10 @@ Copy `.env.example` to `.env`. Key settings:
 | `WIFI_INTERFACE` | wlan0 | WiFi interface name |
 | `WPA_CONFIG_PATH` | /etc/wpa_supplicant/wpa_supplicant.conf | wpa_supplicant config |
 | `WPA_DEBUG_LEVEL` | 2 | Debug verbosity (1-3) |
+| `WPA_MCP_BROWSER_LANG` | _(unset)_ | BCP-47 locale for the in-container browser, e.g. `pt-PT`. Sets `navigator.language`, the `Accept-Language` header, and locale-aware `Intl` formatting. Read at container start — changing requires `make docker-restart`. |
+| `WPA_MCP_BROWSER_TZ` | _(unset)_ | IANA timezone for the in-container browser, e.g. `Europe/Lisbon`. Sets `Intl.DateTimeFormat().resolvedOptions().timeZone`. Browser-scoped only — does not change the container shell clock or log timestamps. Read at container start. |
+
+For i18n captive-portal testing, see [docs/design/14_Browser_Locale_Timezone_Design.md](docs/design/14_Browser_Locale_Timezone_Design.md).
 
 ---
 

--- a/cicd/tests/src/echo-server.mjs
+++ b/cicd/tests/src/echo-server.mjs
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+// Tiny in-container HTTP echo helper for AC2 (Accept-Language) integration test.
+// Listens on 127.0.0.1:8765 and logs every request's headers to stdout.
+// Used by TC-INT-019 to verify the browser sends the configured Accept-Language.
+
+import { createServer } from "http";
+
+createServer((req, res) => {
+  console.log("REQ", req.method, req.url, JSON.stringify(req.headers));
+  res.writeHead(200, { "content-type": "application/json" });
+  res.end(JSON.stringify({ headers: req.headers }));
+}).listen(8765, "127.0.0.1", () => {
+  console.log("echo listening on 127.0.0.1:8765");
+});

--- a/cicd/tests/testcases/integration/TC-INT-018.yml
+++ b/cicd/tests/testcases/integration/TC-INT-018.yml
@@ -1,0 +1,47 @@
+id: TC-INT-018
+name: Browser Locale and Timezone — Full Config Applied
+suite: integration
+priority: 18
+timeout: 60000
+dependencies:
+  - TC-BUILD-002
+tags: [integration, browser, playwright-mcp, i18n, locale, timezone, config, US-BROW-005]
+
+steps:
+  - name: Start container with locale + timezone env vars
+    command: >
+      docker run --rm -d
+      --name wpa-mcp-ci
+      -p 3002:3000
+      -e WPA_MCP_BROWSER_LANG=pt-PT
+      -e WPA_MCP_BROWSER_TZ=Europe/Lisbon
+      wpa-mcp:ci
+    timeout: 15000
+
+  - name: Wait for server + playwright-mcp to bind
+    command: sleep 5
+
+  - name: Verify navigator.language, navigator.languages, and Intl timezone
+    command: >
+      MCP_SERVER_URL=http://localhost:3002/playwright-mcp
+      npx tsx cicd/tests/src/mcp-client.ts call-tool browser_evaluate
+      '{"function":"() => ({ language: navigator.language, languages: Array.from(navigator.languages), timezone: Intl.DateTimeFormat().resolvedOptions().timeZone })"}'
+    expectPatterns:
+      - 'pt-PT'
+      - 'Europe/Lisbon'
+      - 'languages.*pt-PT'
+
+  - name: Stop container
+    command: docker rm -f wpa-mcp-ci
+
+criteria: |
+  Verify WPA_MCP_BROWSER_LANG and WPA_MCP_BROWSER_TZ flow into Chromium contextOptions:
+  - navigator.language === "pt-PT"  (US-BROW-005 AC1)
+  - navigator.languages array contains "pt-PT"  (US-BROW-005 AC1 + transitive AC2)
+  - Intl.DateTimeFormat().resolvedOptions().timeZone === "Europe/Lisbon"  (US-BROW-005 AC3)
+
+  Patterns are loose substrings because mcp-client.ts wraps the MCP response in an
+  outer JSON via JSON.stringify, escaping inner quotes as \"...\". The `languages.*pt-PT`
+  pattern confirms the navigator.languages array contains the configured locale (not
+  just navigator.language), which is the basis Chromium uses to derive the
+  Accept-Language header — TC-INT-019 verifies that header end-to-end.

--- a/cicd/tests/testcases/integration/TC-INT-019.yml
+++ b/cicd/tests/testcases/integration/TC-INT-019.yml
@@ -1,0 +1,63 @@
+id: TC-INT-019
+name: Browser Locale — Accept-Language Header Direct Verification
+suite: integration
+priority: 19
+timeout: 60000
+dependencies:
+  - TC-BUILD-002
+tags: [integration, browser, playwright-mcp, i18n, locale, accept-language, US-BROW-005]
+
+steps:
+  - name: Start container with locale env var
+    command: >
+      docker run --rm -d
+      --name wpa-mcp-ci
+      -p 3002:3000
+      -e WPA_MCP_BROWSER_LANG=pt-PT
+      wpa-mcp:ci
+    timeout: 15000
+
+  - name: Wait for server + playwright-mcp to bind
+    command: sleep 5
+
+  - name: Copy echo server helper into container
+    command: docker cp cicd/tests/src/echo-server.mjs wpa-mcp-ci:/tmp/echo-server.mjs
+
+  - name: Start echo server (background) inside container on 127.0.0.1:8765
+    command: docker exec -d wpa-mcp-ci sh -c 'node /tmp/echo-server.mjs > /tmp/echo.log 2>&1'
+
+  - name: Wait for echo server to bind
+    command: sleep 2
+
+  - name: Verify echo server is listening on 8765 inside container
+    command: docker exec wpa-mcp-ci ss -tln
+    expectPatterns:
+      - '127.0.0.1:8765'
+
+  - name: Drive browser to navigate to the echo endpoint
+    command: >
+      MCP_SERVER_URL=http://localhost:3002/playwright-mcp
+      npx tsx cicd/tests/src/mcp-client.ts call-tool browser_navigate
+      '{"url":"http://127.0.0.1:8765/accept-language-check"}'
+    expectPatterns:
+      - 'Page URL: http://127.0.0.1:8765/accept-language-check'
+
+  - name: Read echo log and confirm Accept-Language header starts with pt-PT
+    command: docker exec wpa-mcp-ci cat /tmp/echo.log
+    expectPatterns:
+      - '"accept-language":"pt-PT'
+
+  - name: Stop container
+    command: docker rm -f wpa-mcp-ci
+
+criteria: |
+  Verify Accept-Language header observed end-to-end on a real HTTP request from the
+  browser (US-BROW-005 AC2 — direct verification, not just navigator.languages
+  derivation).
+
+  Approach: start an in-container HTTP echo server (echo-server.mjs) on
+  127.0.0.1:8765 that logs every inbound request's headers. Drive the proxied
+  playwright-mcp browser to navigate to it. Read the log and confirm
+  `accept-language` starts with `pt-PT`. The pattern tolerates both bare `pt-PT`
+  and weighted form `pt-PT,pt;q=...` because the substring stops before the
+  closing quote.

--- a/cicd/tests/testcases/integration/TC-INT-020.yml
+++ b/cicd/tests/testcases/integration/TC-INT-020.yml
@@ -1,0 +1,45 @@
+id: TC-INT-020
+name: Browser Locale — Partial Config (LANG only, no TZ)
+suite: integration
+priority: 20
+timeout: 60000
+dependencies:
+  - TC-BUILD-002
+tags: [integration, browser, playwright-mcp, i18n, locale, config, US-BROW-005]
+
+steps:
+  - name: Start container with only locale env var
+    command: >
+      docker run --rm -d
+      --name wpa-mcp-ci
+      -p 3002:3000
+      -e WPA_MCP_BROWSER_LANG=de-DE
+      wpa-mcp:ci
+    timeout: 15000
+
+  - name: Wait for server + playwright-mcp to bind
+    command: sleep 5
+
+  - name: Verify locale applied, timezone NOT overridden to Europe/Lisbon
+    command: >
+      MCP_SERVER_URL=http://localhost:3002/playwright-mcp
+      npx tsx cicd/tests/src/mcp-client.ts call-tool browser_evaluate
+      '{"function":"() => ({ language: navigator.language, timezone: Intl.DateTimeFormat().resolvedOptions().timeZone })"}'
+    expectPatterns:
+      - 'de-DE'
+    rejectPatterns:
+      - 'Europe/Lisbon'
+
+  - name: Stop container
+    command: docker rm -f wpa-mcp-ci
+
+criteria: |
+  Verify partial config is a valid configuration (US-BROW-005 AC4):
+  - Setting only WPA_MCP_BROWSER_LANG applies `locale` to the contextOptions
+    (expectPattern catches `de-DE` in the response)
+  - `timezoneId` is omitted from the generated config — browser falls back to
+    Chromium / container default rather than a leftover `Europe/Lisbon` from a
+    different test container (reject pattern guards against cross-test leakage)
+
+  Patterns are loose substrings because mcp-client.ts wraps the MCP response in
+  an outer JSON via JSON.stringify, escaping inner quotes.

--- a/cicd/tests/testcases/integration/TC-INT-021.yml
+++ b/cicd/tests/testcases/integration/TC-INT-021.yml
@@ -1,0 +1,46 @@
+id: TC-INT-021
+name: Browser Locale — Default Mode Regression (No Env Vars)
+suite: integration
+priority: 21
+timeout: 60000
+dependencies:
+  - TC-BUILD-002
+tags: [integration, browser, playwright-mcp, i18n, regression, config, US-BROW-005]
+
+steps:
+  - name: Start container with NO locale or timezone env vars
+    command: >
+      docker run --rm -d
+      --name wpa-mcp-ci
+      -p 3002:3000
+      wpa-mcp:ci
+    timeout: 15000
+
+  - name: Wait for server + playwright-mcp to bind
+    command: sleep 5
+
+  - name: Verify NO config file generated under /tmp
+    command: docker exec wpa-mcp-ci sh -c 'ls /tmp/playwright-mcp-config.json 2>&1 || true'
+    expectPatterns:
+      - 'No such file or directory'
+
+  - name: Verify playwright-mcp process was launched WITHOUT --config flag
+    command: docker exec wpa-mcp-ci sh -c 'ps -ef | grep playwright-mcp | grep -v grep'
+    rejectPatterns:
+      - '--config'
+
+  - name: Stop container
+    command: docker rm -f wpa-mcp-ci
+
+criteria: |
+  Verify the regression guard (US-BROW-005 AC5): when both env vars are unset,
+  the feature is invisible.
+
+  Two precise, deterministic checks:
+  - /tmp/playwright-mcp-config.json does NOT exist in the container
+  - The running playwright-mcp process command line does NOT contain `--config`
+
+  Together these lock in Decision #2 from 14_Browser_Locale_Timezone_Design.md:
+  the unset path is byte-equivalent to the pre-feature invocation. A
+  browser-locale fallback check was considered but rejected — Chromium's default
+  locale varies by host and base image, making it a fragile assertion.

--- a/cicd/tests/testcases/integration/TC-INT-022.yml
+++ b/cicd/tests/testcases/integration/TC-INT-022.yml
@@ -1,0 +1,48 @@
+id: TC-INT-022
+name: Browser Timezone — Invalid IANA ID Surfaces Clear Error
+suite: integration
+priority: 22
+timeout: 60000
+dependencies:
+  - TC-BUILD-002
+tags: [integration, browser, playwright-mcp, i18n, timezone, error, US-BROW-005]
+
+steps:
+  - name: Start container with invalid timezone
+    command: >
+      docker run --rm -d
+      --name wpa-mcp-ci
+      -p 3002:3000
+      -e WPA_MCP_BROWSER_TZ=Mars/Olympus_Mons
+      wpa-mcp:ci
+    timeout: 15000
+
+  - name: Wait for server + playwright-mcp to bind
+    command: sleep 5
+
+  - name: Drive browser_navigate — expect context-creation error
+    command: >
+      MCP_SERVER_URL=http://localhost:3002/playwright-mcp
+      npx tsx cicd/tests/src/mcp-client.ts call-tool browser_navigate
+      '{"url":"about:blank"}'
+    expectPatterns:
+      - 'isError'
+      - 'Invalid timezone ID'
+      - 'Mars/Olympus_Mons'
+
+  - name: Stop container
+    command: docker rm -f wpa-mcp-ci
+
+criteria: |
+  Verify invalid IANA timezone fails fast with a clear error (US-BROW-005 AC7).
+
+  Patterns are based on an actual probe against @playwright/mcp@0.0.70:
+  - `isError` confirms the CallToolResult.isError flag is true
+  - `Invalid timezone ID` is the upstream error wording at browser-context
+    creation time
+  - `Mars/Olympus_Mons` confirms the user-supplied invalid value flows through
+    in the error message (not just a generic "bad config")
+
+  Together these prove the error is surfaced, clear, and traces back to the
+  specific bad input — rather than the container silently falling back to UTC
+  or the playwright-mcp subprocess crashing.

--- a/cicd/tests/testcases/integration/TC-INT-023.yml
+++ b/cicd/tests/testcases/integration/TC-INT-023.yml
@@ -1,0 +1,30 @@
+id: TC-INT-023
+name: Browser Locale and Timezone — README Documents Env Vars
+suite: integration
+priority: 23
+timeout: 10000
+dependencies: []
+tags: [integration, docs, i18n, US-BROW-005]
+
+steps:
+  - name: Verify README's Environment Variables table includes both env vars
+    command: grep -E 'WPA_MCP_BROWSER_LANG|WPA_MCP_BROWSER_TZ' README.md
+    expectPatterns:
+      - 'WPA_MCP_BROWSER_LANG'
+      - 'WPA_MCP_BROWSER_TZ'
+
+  - name: Verify README mentions example values (pt-PT and Europe/Lisbon)
+    command: grep -E 'pt-PT|Europe/Lisbon' README.md
+    expectPatterns:
+      - 'pt-PT'
+      - 'Europe/Lisbon'
+
+criteria: |
+  Verify both new env vars and their example values are documented in README.md
+  (US-BROW-005 AC6).
+
+  This is a paper-trail AC — without it, an operator pulling the image won't
+  discover the i18n knobs. The grep is two-pass so a failure points clearly at
+  either missing variable names or missing example values.
+
+  No container required; this is a pure repository-content check.

--- a/deploy/wpa-mcp-start
+++ b/deploy/wpa-mcp-start
@@ -52,6 +52,8 @@ docker run --rm -d \
   -e "WIFI_INTERFACE=$IFACE" \
   -e "WPA_DEBUG_LEVEL=$DEBUG_LEVEL" \
   -e "PORT=3000" \
+  -e "WPA_MCP_BROWSER_LANG=${WPA_MCP_BROWSER_LANG:-}" \
+  -e "WPA_MCP_BROWSER_TZ=${WPA_MCP_BROWSER_TZ:-}" \
   "$IMAGE" >/dev/null
 
 PID=$(docker inspect --format '{{.State.Pid}}' "$CONTAINER")

--- a/deploy/wpa-mcp.service
+++ b/deploy/wpa-mcp.service
@@ -15,6 +15,13 @@ Environment=PORT=3000
 Environment=WPA_DEBUG_LEVEL=2
 Environment=WPA_MCP_VOLUME=wpa-mcp-data
 
+# Optional: configure the in-container browser's locale and timezone for
+# i18n captive-portal testing. Both are read at container start; changing
+# them requires a service restart. See
+# docs/design/14_Browser_Locale_Timezone_Design.md.
+#Environment=WPA_MCP_BROWSER_LANG=pt-PT
+#Environment=WPA_MCP_BROWSER_TZ=Europe/Lisbon
+
 ExecStart=/usr/local/sbin/wpa-mcp-start
 ExecStop=/usr/bin/docker rm -f wpa-mcp
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -70,6 +70,41 @@ echo "entrypoint: starting Microsoft Playwright MCP on 127.0.0.1:${PLAYWRIGHT_MC
 #                                     is always writable.
 PLAYWRIGHT_MCP_OUTPUT_DIR=/tmp/playwright-mcp-output
 mkdir -p "$PLAYWRIGHT_MCP_OUTPUT_DIR"
+
+# Optional i18n knobs for the headless Chromium spawned by playwright-mcp.
+# When either env var is set, generate a minimal config JSON and pass it via
+# --config. When both are unset, no config file is generated and no --config
+# flag is appended — the launch is byte-identical to the pre-feature
+# invocation. See docs/design/14_Browser_Locale_Timezone_Design.md.
+PW_CONFIG_FLAG=""
+if [[ -n "${WPA_MCP_BROWSER_LANG:-}" || -n "${WPA_MCP_BROWSER_TZ:-}" ]]; then
+  PW_CONFIG_PATH=/tmp/playwright-mcp-config.json
+
+  # Build the inner contextOptions field-by-field so a one-of-two config
+  # stays valid JSON (no trailing comma, no orphan field).
+  PW_CONTEXT_OPTS=""
+  if [[ -n "${WPA_MCP_BROWSER_LANG:-}" ]]; then
+    PW_CONTEXT_OPTS="\"locale\": \"${WPA_MCP_BROWSER_LANG}\""
+  fi
+  if [[ -n "${WPA_MCP_BROWSER_TZ:-}" ]]; then
+    if [[ -n "$PW_CONTEXT_OPTS" ]]; then
+      PW_CONTEXT_OPTS="${PW_CONTEXT_OPTS}, "
+    fi
+    PW_CONTEXT_OPTS="${PW_CONTEXT_OPTS}\"timezoneId\": \"${WPA_MCP_BROWSER_TZ}\""
+  fi
+
+  cat > "$PW_CONFIG_PATH" <<EOF
+{ "browser": { "contextOptions": { ${PW_CONTEXT_OPTS} } } }
+EOF
+
+  echo "entrypoint: generated playwright-mcp config at $PW_CONFIG_PATH (locale=${WPA_MCP_BROWSER_LANG:-<default>}, timezoneId=${WPA_MCP_BROWSER_TZ:-<default>})"
+  PW_CONFIG_FLAG="--config $PW_CONFIG_PATH"
+fi
+
+# NB: $PW_CONFIG_FLAG is intentionally unquoted so that when empty it
+# expands to zero arguments, and when set it word-splits into two args
+# (`--config` and the path). The path is hardcoded so word-splitting is
+# safe; values from the env vars only appear inside the JSON, not the flag.
 playwright-mcp \
   --headless \
   --browser chromium \
@@ -78,6 +113,7 @@ playwright-mcp \
   --output-dir "$PLAYWRIGHT_MCP_OUTPUT_DIR" \
   --port "${PLAYWRIGHT_MCP_PORT}" \
   --host 127.0.0.1 \
+  $PW_CONFIG_FLAG \
   > /tmp/playwright-mcp.log 2>&1 &
 PLAYWRIGHT_MCP_PID=$!
 

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -13,10 +13,12 @@
 #   sudo ./docker/run.sh [WIFI_INTERFACE]
 #
 # Environment (can be set in .env at project root):
-#   WIFI_INTERFACE   WiFi interface name (default: wlan0, or first arg)
-#   WPA_MCP_IMAGE    Docker image name  (default: wpa-mcp:latest)
-#   PORT             Host port to forward (default: 3000)
-#   WPA_DEBUG_LEVEL  Debug verbosity 1-3 (default: 2)
+#   WIFI_INTERFACE         WiFi interface name (default: wlan0, or first arg)
+#   WPA_MCP_IMAGE          Docker image name  (default: wpa-mcp:latest)
+#   PORT                   Host port to forward (default: 3000)
+#   WPA_DEBUG_LEVEL        Debug verbosity 1-3 (default: 2)
+#   WPA_MCP_BROWSER_LANG   BCP-47 locale for the in-container browser (e.g. pt-PT)
+#   WPA_MCP_BROWSER_TZ     IANA timezone for the in-container browser (e.g. Europe/Lisbon)
 #
 set -euo pipefail
 
@@ -114,6 +116,8 @@ docker run --rm -d \
   -e "WPA_DEBUG_LEVEL=${DEBUG_LEVEL}" \
   -e "PORT=3000" \
   -e "PLAYWRIGHT_MCP_PORT=8931" \
+  -e "WPA_MCP_BROWSER_LANG=${WPA_MCP_BROWSER_LANG:-}" \
+  -e "WPA_MCP_BROWSER_TZ=${WPA_MCP_BROWSER_TZ:-}" \
   "$IMAGE"
 
 # --- Move WiFi phy into container netns ---

--- a/docs/README.md
+++ b/docs/README.md
@@ -197,6 +197,7 @@ portals on the WLAN joined via `wifi_connect`). Full design:
 | 11 | [Credential Store](./design/11_Credential_Store_Design.md) | Certificate storage system design |
 | 12 | [HS20 / Passpoint](./design/12_HS20_Design.md) | Hotspot 2.0 auto-discovery design |
 | 13 | [Dual-MCP Playwright](./design/13_Dual_MCP_Playwright_Design.md) | `/playwright-mcp` reverse proxy design |
+| 14 | [Browser Locale and Timezone](./design/14_Browser_Locale_Timezone_Design.md) | Env-var driven Chromium i18n for captive-portal testing |
 | — | [MAC Address Restoration](./design/mac-address-restoration.md) | Docker MAC address decision record |
 
 ### User Stories

--- a/docs/design/14_Browser_Locale_Timezone_Design.md
+++ b/docs/design/14_Browser_Locale_Timezone_Design.md
@@ -1,0 +1,265 @@
+# Browser Locale and Timezone Design
+
+**Status:** Draft
+**Created:** 2026-05-11
+**Related:** [13_Dual_MCP_Playwright_Design.md](./13_Dual_MCP_Playwright_Design.md), [03_Browser_Tools.md](../reference/03_Browser_Tools.md), [GitHub Issue #47](https://github.com/dogkeeper886/wpa-mcp/issues/47)
+
+---
+
+> **Note:** This is a design document. For usage reference, see [03_Browser_Tools.md](../reference/03_Browser_Tools.md) once implemented.
+
+---
+
+## Goal
+
+Allow a tester to configure the locale and timezone of the headless Chromium that the in-container `@playwright/mcp` subprocess launches, via two new environment variables — `WPA_MCP_BROWSER_LANG` and `WPA_MCP_BROWSER_TZ`. This unblocks i18n testing of captive portals: verifying that a portal popup (and any server-side artifact it triggers, e.g. OTP/notification emails) honors a visitor's browser locale, without hand-patching the container.
+
+---
+
+## Current State
+
+The `@playwright/mcp` subprocess is launched by `docker/entrypoint.sh` with a fixed flag list (`--headless`, `--browser chromium`, `--no-sandbox`, `--allow-unrestricted-file-access`, `--output-dir`, `--port`, `--host`). The Chromium it spawns therefore reports its default locale and timezone:
+
+- `navigator.language` defaults to the system locale (effectively `en-US` / `C`).
+- `Accept-Language` is derived from that default.
+- `Intl.DateTimeFormat().resolvedOptions().timeZone` reflects the host or `UTC`.
+
+For an i18n verification flow — *"if a visitor's browser is `pt-PT`, does the portal popup AND the email it triggers come back in Portuguese?"* — the only ways to change locale today are:
+
+1. Editing `docker/entrypoint.sh` locally and rebuilding the image, or
+2. Killing the in-container `playwright-mcp` subprocess and relaunching it by hand with extra arguments.
+
+Both are off the happy path for an MCP user driving the container from a Claude client.
+
+---
+
+## User Flow
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Tester sets env vars before starting the container             │
+│                                                                 │
+│    # .env  (or `docker run -e ...`)                             │
+│    WPA_MCP_BROWSER_LANG=pt-PT                                   │
+│    WPA_MCP_BROWSER_TZ=Europe/Lisbon                             │
+└────────────────────────────────┬────────────────────────────────┘
+                                 │
+                                 ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  sudo make docker-start                                         │
+│                                                                 │
+│  run.sh forwards both vars into the container                   │
+│  entrypoint.sh sees at least one var set, generates             │
+│    /tmp/playwright-mcp-config.json:                             │
+│    { "browser": { "contextOptions": {                           │
+│        "locale": "pt-PT",                                       │
+│        "timezoneId": "Europe/Lisbon"                            │
+│    } } }                                                        │
+│  entrypoint.sh adds `--config /tmp/playwright-mcp-config.json`  │
+│  to the playwright-mcp launch                                   │
+└────────────────────────────────┬────────────────────────────────┘
+                                 │
+                                 ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  Tester drives wpa-playwright as usual                          │
+│                                                                 │
+│  wifi_connect → join WLAN behind captive portal                 │
+│  browser_navigate → first nav launches Chromium with the        │
+│    configured contextOptions applied                            │
+└────────────────────────────────┬────────────────────────────────┘
+                                 │
+                                 ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  Portal sees `Accept-Language: pt-PT` and serves Portuguese    │
+│  page. navigator.language === "pt-PT" inside the browser.       │
+│  Intl.DateTimeFormat times in Europe/Lisbon.                    │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│  Host                                                                 │
+│                                                                       │
+│  .env / `docker run -e ...` / systemd Environment=                    │
+│    WPA_MCP_BROWSER_LANG=pt-PT                                         │
+│    WPA_MCP_BROWSER_TZ=Europe/Lisbon                                   │
+│                                                                       │
+└────────────────────────────────┬─────────────────────────────────────┘
+                                 │  docker run -e WPA_MCP_BROWSER_LANG \
+                                 │            -e WPA_MCP_BROWSER_TZ
+                                 ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│  Container (entrypoint.sh)                                            │
+│                                                                       │
+│   if [[ -n "$WPA_MCP_BROWSER_LANG" || -n "$WPA_MCP_BROWSER_TZ" ]];    │
+│   then                                                                │
+│     write /tmp/playwright-mcp-config.json with contextOptions         │
+│     PW_CONFIG_FLAG="--config /tmp/playwright-mcp-config.json"         │
+│   else                                                                │
+│     PW_CONFIG_FLAG=""    ← no config file, unchanged behavior         │
+│   fi                                                                  │
+│                                                                       │
+│   playwright-mcp \                                                    │
+│     --headless --browser chromium --no-sandbox \                      │
+│     --allow-unrestricted-file-access --output-dir ... \               │
+│     --port 8931 --host 127.0.0.1 \                                    │
+│     $PW_CONFIG_FLAG                                                   │
+│                                                                       │
+└────────────────────────────────┬─────────────────────────────────────┘
+                                 │
+                                 ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│  @playwright/mcp subprocess                                           │
+│                                                                       │
+│  Reads /tmp/playwright-mcp-config.json once at startup.               │
+│  Applies browser.contextOptions to every Chromium context it          │
+│  creates (first browser_navigate spawns Chromium with the locale      │
+│  and timezoneId baked in).                                            │
+└────────────────────────────────┬─────────────────────────────────────┘
+                                 │  Chrome DevTools Protocol
+                                 ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│  Headless Chromium                                                    │
+│                                                                       │
+│  • navigator.language === locale                                      │
+│  • navigator.languages === [locale]                                   │
+│  • Accept-Language: locale on every request                           │
+│  • Intl.DateTimeFormat().resolvedOptions().timeZone === timezoneId    │
+│  • Number / date formatting follows locale rules                      │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## API
+
+### Environment Variables
+
+| Variable | Default | Type | Example | Effect |
+|---|---|---|---|---|
+| `WPA_MCP_BROWSER_LANG` | unset | BCP-47 locale string | `pt-PT`, `de-DE`, `en-GB`, `ja-JP` | Sets `browser.contextOptions.locale` in the generated config. Drives `navigator.language`, `Accept-Language`, and locale-aware `Intl` formatting. |
+| `WPA_MCP_BROWSER_TZ` | unset | IANA timezone ID | `Europe/Lisbon`, `Asia/Tokyo`, `America/Los_Angeles` | Sets `browser.contextOptions.timezoneId`. Drives `Intl.DateTimeFormat().resolvedOptions().timeZone` and `Date()` wall-clock output. |
+
+When **both** are unset, no config file is generated and no `--config` flag is added to the playwright-mcp launch — the container behaves exactly as before. When **either** is set, a single config file is generated covering whichever fields are present.
+
+### Generated Config Shape
+
+`@playwright/mcp@0.0.70` consumes `--config <path>` and reads a JSON file matching its [public `Config` shape](https://github.com/microsoft/playwright-mcp/blob/main/config.d.ts) (also shipped at `/usr/local/lib/node_modules/@playwright/mcp/config.d.ts` in the container). The minimal shape this feature emits:
+
+```json
+{
+  "browser": {
+    "contextOptions": {
+      "locale": "pt-PT",
+      "timezoneId": "Europe/Lisbon"
+    }
+  }
+}
+```
+
+Either inner key is omitted when its env var is unset.
+
+### Observable Effects
+
+For `WPA_MCP_BROWSER_LANG=pt-PT` and `WPA_MCP_BROWSER_TZ=Europe/Lisbon` after `make docker-start`, with `browser_evaluate` against `about:blank`:
+
+```js
+navigator.language                                  // → "pt-PT"
+navigator.languages                                 // → ["pt-PT"]
+Intl.DateTimeFormat().resolvedOptions().timeZone    // → "Europe/Lisbon"
+Intl.DateTimeFormat().resolvedOptions().locale      // → "pt-PT"
+new Intl.NumberFormat().format(1234.5)              // → "1234,5"
+new Date().toString()                               // → "... GMT+0100 (Hora de verão da Europa Ocidental)"
+```
+
+And every outbound request from the browser carries `Accept-Language: pt-PT`.
+
+---
+
+## Design Decisions
+
+### 1. `--config <json>` over `--browser-arg=--lang=` (issue's original proposal)
+
+**Choice:** Drive locale and timezone through a generated `--config` JSON, not Chromium browser-args.
+
+**Rationale:** The issue proposed `--browser-arg=--lang=<value>`. That CLI flag does **not exist** in `@playwright/mcp@0.0.70` (verified via `playwright-mcp --help`). What the pinned version *does* expose is `--config <path>` accepting a `browser.contextOptions` object — and Playwright's `BrowserContextOptions.locale` documents that it sets `navigator.language`, the `Accept-Language` header, *and* `Intl` formatting rules in one stroke. `BrowserContextOptions.timezoneId` covers `Intl.DateTimeFormat().resolvedOptions().timeZone`. One mechanism, all three acceptance criteria, one upstream-supported config schema. (POC against the running container verified all three plus locale-aware number/date formatting on a real Amazon page.)
+
+### 2. Generate the config file at entrypoint, don't ship a static template
+
+**Choice:** Write the JSON inline in `docker/entrypoint.sh` only when at least one env var is set; remove the file otherwise.
+
+**Rationale:** Conditional generation keeps the default path untouched — no `--config` flag is added when nobody asked for one, which preserves the exact pre-feature `playwright-mcp` invocation byte-for-byte. A shipped static template would always pass `--config` and rely on default fields, which couples the feature's existence to its activation. CLAUDE.md: *"Don't add features, refactor, or introduce abstractions beyond what the task requires"* — adding the `--config` arg only when needed honors that principle.
+
+### 3. Keep the two env vars separate (vs. one combined config-blob var)
+
+**Choice:** `WPA_MCP_BROWSER_LANG` and `WPA_MCP_BROWSER_TZ` are independent env vars; either can be set without the other.
+
+**Rationale:** The container already configures itself via discrete env vars (`PORT`, `WIFI_INTERFACE`, `WPA_DEBUG_LEVEL`, `PLAYWRIGHT_MCP_PORT`, `WPA_MCP_VOLUME`). Two more fits that surface. A combined `WPA_MCP_BROWSER_CONFIG_JSON='{"...":"..."}'` would push raw JSON through shell quoting and `.env` parsing — a worse user experience for a 1-line config.
+
+### 4. Pass-through plumbing in `docker/run.sh` and `deploy/wpa-mcp.service`
+
+**Choice:** Add explicit `-e WPA_MCP_BROWSER_LANG` / `-e WPA_MCP_BROWSER_TZ` lines to `docker/run.sh`'s `docker run` block, and commented-out `Environment=` lines to the systemd unit.
+
+**Rationale:** `docker run` only forwards env vars that are explicitly listed; the variables would be invisible to `entrypoint.sh` without this plumbing. The systemd unit follows the existing pattern of listing every supported var so an operator can uncomment a line without going to look up the name.
+
+### 5. No runtime tool to change locale mid-session
+
+**Choice:** No `wifi_set_locale` MCP tool. Locale is set at container start.
+
+**Rationale:** Playwright's `contextOptions` are applied at **context creation** — i.e., at `playwright-mcp` launch, which is at `docker run` time for our setup. A live `wpa-playwright` session whose browser is already running cannot pick up a new locale without bouncing the subprocess. A runtime tool would either be a lie (no effect until restart) or would require a tear-down/relaunch flow that loses the active browser session. For a setup-time test config knob, env vars at `docker run` time are the right shape; document the limitation explicitly.
+
+### 6. Defer shell-level system locale to a follow-up
+
+**Choice:** This feature controls *browser* locale only. The container's shell `LANG`, `LC_ALL`, log timestamps, etc. are not changed.
+
+**Rationale:** A full system locale would additionally require installing the `locales` apt package and running `locale-gen <locale>.UTF-8` in the Dockerfile — extra image size and build time for a use case nobody has asked for yet. Browser locale alone satisfies the i18n captive-portal test goal. Explicitly **out of scope:** container shell `LANG` / `LC_ALL`, `date` command output, log timestamps, anything outside the headless Chromium process. If a real use case for shell-level locale appears, add it then.
+
+### 7. No Dockerfile changes for `TZ`
+
+**Choice:** Rely on the existing `tzdata` package in the `node:22-slim` base image; no Dockerfile change needed. Container shell clock (`date`, log timestamps) is **not** changed — only the browser's view of timezone.
+
+**Rationale:** The base image already ships the full IANA tzdata, so any `Europe/Lisbon`-style ID resolves. `BrowserContextOptions.timezoneId` is applied via CDP at context creation, so the override lives inside the headless Chromium process. The shell's clock is intentionally left alone to avoid surprising side effects on logs and process timestamps.
+
+---
+
+## Error Handling
+
+| Scenario | Behavior | Resolution |
+|---|---|---|
+| Both env vars unset | No config file generated; no `--config` flag added; behavior is identical to today. | (Intentional — this is the default.) |
+| `WPA_MCP_BROWSER_LANG` set, `WPA_MCP_BROWSER_TZ` unset | Config file generated with only `locale`; `timezoneId` omitted; `Intl.DateTimeFormat` resolves to host/UTC default. | (Intentional — partial config is valid.) |
+| Invalid BCP-47 locale (e.g. `WPA_MCP_BROWSER_LANG=garbage`) | Playwright passes the string to Chromium; Chromium accepts most strings but may produce odd `Accept-Language` values. No crash. | Set a valid locale like `pt-PT`. The container surfaces no validation today — same posture as `WIFI_INTERFACE`. |
+| Invalid IANA timezone (e.g. `WPA_MCP_BROWSER_TZ=Mars/Olympus_Mons`) | Playwright throws when creating a browser context; `browser_navigate` returns a context-creation error. | Set a valid IANA timezone like `Europe/Lisbon`. |
+| Config file write fails (`/tmp` not writable) | `entrypoint.sh` exits non-zero before launching `playwright-mcp` thanks to `set -euo pipefail`. The container fails to start with a clear error in `docker logs`. | Container-level issue — `/tmp` is always writable inside a normal container. |
+| Need to change locale at runtime | Not supported. | `make docker-restart` after updating the env var. Document this as a known limitation. |
+
+---
+
+## Files to Modify
+
+| File | Change |
+|---|---|
+| `docker/entrypoint.sh` | Add a config-generation block before the `playwright-mcp` invocation; conditionally append `--config /tmp/playwright-mcp-config.json` to the flag list. |
+| `docker/run.sh` | Add `-e WPA_MCP_BROWSER_LANG` and `-e WPA_MCP_BROWSER_TZ` to the `docker run` env-passthrough block (alongside `WIFI_INTERFACE`, `WPA_DEBUG_LEVEL`, `PORT`, `PLAYWRIGHT_MCP_PORT`). |
+| `deploy/wpa-mcp.service` | Add two commented-out `Environment=` lines so an operator can uncomment to enable. |
+| `.env.example` | Add two commented examples with realistic values (`pt-PT`, `Europe/Lisbon`). |
+| `README.md` | Add both vars to the "Environment Variables" table with concrete example values and a one-line note about the "set at `docker run` time" limitation. |
+| `docs/README.md` | Add this design doc (number 14) to the Document Index. |
+| `docs/user-stories/42_Browser_Stories.md` | Append the new browser-locale story (added by `/user-stories`). |
+| `cicd/tests/testcases/integration/` | Add a YAML test case asserting all three observable effects (added by `/ci-testcase`). |
+
+No source-tree (`src/`) changes — the feature lives entirely in the container's launch wiring; the wpa-mcp Node server and its proxy are not involved.
+
+---
+
+## Related Documents
+
+- [13_Dual_MCP_Playwright_Design.md](./13_Dual_MCP_Playwright_Design.md) — the dual-MCP architecture this feature plugs into; explains why playwright-mcp runs as a subprocess inside the container and is launched by `docker/entrypoint.sh`.
+- [03_Browser_Tools.md](../reference/03_Browser_Tools.md) — browser-tool reference; the place to surface the new env vars to end users.
+- [05_Docker_Netns_Isolation.md](../reference/05_Docker_Netns_Isolation.md) — context on why the browser must live in the container (captive-portal reachability), which is the whole reason i18n testing happens inside the container.
+- [`@playwright/mcp` config schema](https://github.com/microsoft/playwright-mcp/blob/main/config.d.ts) — upstream definition of `browser.contextOptions`. Also shipped in the container at `/usr/local/lib/node_modules/@playwright/mcp/config.d.ts`.
+- [GitHub Issue #47](https://github.com/dogkeeper886/wpa-mcp/issues/47) — original feature request; the mechanism described there (`--browser-arg=--lang=`) was superseded by the `--config <json>` approach during POC.

--- a/docs/design/14_Browser_Locale_Timezone_Design.md
+++ b/docs/design/14_Browser_Locale_Timezone_Design.md
@@ -246,6 +246,7 @@ And every outbound request from the browser carries `Accept-Language: pt-PT`.
 | `docker/entrypoint.sh` | Add a config-generation block before the `playwright-mcp` invocation; conditionally append `--config /tmp/playwright-mcp-config.json` to the flag list. |
 | `docker/run.sh` | Add `-e WPA_MCP_BROWSER_LANG` and `-e WPA_MCP_BROWSER_TZ` to the `docker run` env-passthrough block (alongside `WIFI_INTERFACE`, `WPA_DEBUG_LEVEL`, `PORT`, `PLAYWRIGHT_MCP_PORT`). |
 | `deploy/wpa-mcp.service` | Add two commented-out `Environment=` lines so an operator can uncomment to enable. |
+| `deploy/wpa-mcp-start` | Mirror the `-e WPA_MCP_BROWSER_LANG` / `-e WPA_MCP_BROWSER_TZ` lines into the systemd-invoked startup script (it has its own `docker run` block separate from `docker/run.sh`). |
 | `.env.example` | Add two commented examples with realistic values (`pt-PT`, `Europe/Lisbon`). |
 | `README.md` | Add both vars to the "Environment Variables" table with concrete example values and a one-line note about the "set at `docker run` time" limitation. |
 | `docs/README.md` | Add this design doc (number 14) to the Document Index. |

--- a/docs/design/14_Browser_Locale_Timezone_Design.md
+++ b/docs/design/14_Browser_Locale_Timezone_Design.md
@@ -1,6 +1,6 @@
 # Browser Locale and Timezone Design
 
-**Status:** Draft
+**Status:** Complete
 **Created:** 2026-05-11
 **Related:** [13_Dual_MCP_Playwright_Design.md](./13_Dual_MCP_Playwright_Design.md), [03_Browser_Tools.md](../reference/03_Browser_Tools.md), [GitHub Issue #47](https://github.com/dogkeeper886/wpa-mcp/issues/47)
 

--- a/docs/user-stories/42_Browser_Stories.md
+++ b/docs/user-stories/42_Browser_Stories.md
@@ -158,13 +158,13 @@ As a user driving a captive portal through the proxied `wpa-playwright` MCP, I w
 
 | AC# | Test Case | Status |
 |-----|-----------|--------|
-| 1 | TC-INT-018 | Covered (specs written, pending implementation) |
-| 2 | TC-INT-019 | Covered (specs written, pending implementation) |
-| 3 | TC-INT-018 | Covered (specs written, pending implementation) |
-| 4 | TC-INT-020 | Covered (specs written, pending implementation) |
-| 5 | TC-INT-021 | Covered (specs written, pending implementation) |
-| 6 | TC-INT-023 | Covered (specs written, pending implementation) |
-| 7 | TC-INT-022 | Covered (specs written, pending implementation) |
+| 1 | TC-INT-018 | Covered |
+| 2 | TC-INT-019 | Covered |
+| 3 | TC-INT-018 | Covered |
+| 4 | TC-INT-020 | Covered |
+| 5 | TC-INT-021 | Covered |
+| 6 | TC-INT-023 | Covered |
+| 7 | TC-INT-022 | Covered |
 
 ### Tags
 
@@ -180,6 +180,6 @@ As a user driving a captive portal through the proxied `wpa-playwright` MCP, I w
 | US-BROW-002 | AC1-7 | — | No test |
 | US-BROW-003 | AC1-4 | — | No test |
 | US-BROW-004 | AC1-10 | — | No test |
-| US-BROW-005 | AC1-7 | TC-INT-018, TC-INT-019, TC-INT-020, TC-INT-021, TC-INT-022, TC-INT-023 | Specs written, pending implementation |
+| US-BROW-005 | AC1-7 | TC-INT-018, TC-INT-019, TC-INT-020, TC-INT-021, TC-INT-022, TC-INT-023 | Covered |
 
-**Coverage:** 7/31 ACs have test coverage (24 pre-existing stories still have no tests; all 7 ACs of US-BROW-005 covered by 6 new TC-INT specs that will run against the wpa-mcp:ci image once the feature is implemented).
+**Coverage:** 7/31 ACs have test coverage (24 pre-existing stories still have no tests; all 7 ACs of US-BROW-005 covered by 6 new TC-INT specs that run against the wpa-mcp:ci image — all green at 2026-05-12).

--- a/docs/user-stories/42_Browser_Stories.md
+++ b/docs/user-stories/42_Browser_Stories.md
@@ -2,8 +2,8 @@
 
 **Status:** Draft
 **Created:** 2026-04-10
-**Updated:** 2026-04-23
-**Source:** [src/tools/browser.ts](../../src/tools/browser.ts) | [src/index.ts](../../src/index.ts) | [03_Browser_Tools](../reference/03_Browser_Tools.md) | [13_Dual_MCP_Playwright_Design](../design/13_Dual_MCP_Playwright_Design.md)
+**Updated:** 2026-05-11
+**Source:** [src/tools/browser.ts](../../src/tools/browser.ts) | [src/index.ts](../../src/index.ts) | [03_Browser_Tools](../reference/03_Browser_Tools.md) | [13_Dual_MCP_Playwright_Design](../design/13_Dual_MCP_Playwright_Design.md) | [14_Browser_Locale_Timezone_Design](../design/14_Browser_Locale_Timezone_Design.md)
 
 ---
 
@@ -131,6 +131,47 @@ As a user driving an unknown captive portal (e.g. WISPr, vendor-specific hotel p
 
 ---
 
+## US-BROW-005: Configure Browser Locale and Timezone for i18n Captive-Portal Testing
+
+**Env vars:** `WPA_MCP_BROWSER_LANG`, `WPA_MCP_BROWSER_TZ` | **Ref:** [14_Browser_Locale_Timezone_Design](../design/14_Browser_Locale_Timezone_Design.md) | **Issue:** [#47](https://github.com/dogkeeper886/wpa-mcp/issues/47)
+
+As a user driving a captive portal through the proxied `wpa-playwright` MCP, I want to set the browser's locale and timezone at container start, so that I can verify the portal popup — and any server-generated artifacts it triggers (OTP / notification emails) — render in the visitor's expected language without hand-patching the container.
+
+### Acceptance Criteria
+
+1. With `WPA_MCP_BROWSER_LANG=pt-PT` set on `docker run`, `browser_evaluate` returning `navigator.language` resolves to `pt-PT` and `navigator.languages` is an array starting with `pt-PT`.
+2. With `WPA_MCP_BROWSER_LANG=pt-PT`, every outbound HTTP request the browser makes carries an `Accept-Language` header beginning with `pt-PT` (exact `pt-PT` or weighted form `pt-PT,pt;q=…`).
+3. With `WPA_MCP_BROWSER_TZ=Europe/Lisbon` set on `docker run`, `browser_evaluate` returning `Intl.DateTimeFormat().resolvedOptions().timeZone` resolves to `Europe/Lisbon`.
+4. Either env var alone is a valid configuration — setting only `WPA_MCP_BROWSER_LANG` applies only `locale`; setting only `WPA_MCP_BROWSER_TZ` applies only `timezoneId`; the other field falls back to Chromium default.
+5. When **both** env vars are unset, the `playwright-mcp` launch arguments are byte-identical to the pre-feature invocation: no config file is generated under `/tmp/`, and no `--config` flag is appended (regression guard).
+6. README's "Environment Variables" table documents both `WPA_MCP_BROWSER_LANG` and `WPA_MCP_BROWSER_TZ` with concrete example values (e.g. `pt-PT`, `Europe/Lisbon`) and a one-line note that they are read at container start.
+7. Setting `WPA_MCP_BROWSER_TZ` to an invalid IANA timezone string (e.g. `Mars/Olympus_Mons`) surfaces as a clear context-creation error on the first `browser_navigate` call rather than failing silently or producing UTC.
+
+### Notes
+
+- **Non-functional constraint — bind at container start.** Playwright's `contextOptions` are applied at Chromium context creation, which is the first `browser_navigate` after the `playwright-mcp` subprocess launches. Changing either env var mid-life has no effect until `make docker-restart` (or equivalent). This is documented as a known limitation, not a bug.
+- **Browser scope only.** These env vars affect *only* the headless Chromium that `playwright-mcp` spawns. They do **not** change the container shell's `LANG` / `LC_ALL`, the output of `date`, or the timestamps in `/tmp/wpa_supplicant_*.log`. A full system locale is out of scope (would require the `locales` apt package + `locale-gen`).
+- **Invalid locale strings are silently accepted.** Chromium does not validate `navigator.language` content; an unknown locale (e.g. `garbage`) is forwarded as-is to the `Accept-Language` header and `navigator.language`. Only invalid timezone IDs throw at context creation (covered by AC7).
+- The implementation lives entirely in `docker/entrypoint.sh` plus passthrough plumbing in `docker/run.sh`, `deploy/wpa-mcp.service`, and `.env.example`. No `src/` changes.
+
+### Test Mapping
+
+| AC# | Test Case | Status |
+|-----|-----------|--------|
+| 1 | TC-INT-018 | Covered (specs written, pending implementation) |
+| 2 | TC-INT-019 | Covered (specs written, pending implementation) |
+| 3 | TC-INT-018 | Covered (specs written, pending implementation) |
+| 4 | TC-INT-020 | Covered (specs written, pending implementation) |
+| 5 | TC-INT-021 | Covered (specs written, pending implementation) |
+| 6 | TC-INT-023 | Covered (specs written, pending implementation) |
+| 7 | TC-INT-022 | Covered (specs written, pending implementation) |
+
+### Tags
+
+`browser`, `playwright-mcp`, `i18n`, `locale`, `timezone`, `captive-portal`, `config`
+
+---
+
 ## Traceability Matrix
 
 | Story | AC | Test Case | Status |
@@ -139,5 +180,6 @@ As a user driving an unknown captive portal (e.g. WISPr, vendor-specific hotel p
 | US-BROW-002 | AC1-7 | — | No test |
 | US-BROW-003 | AC1-4 | — | No test |
 | US-BROW-004 | AC1-10 | — | No test |
+| US-BROW-005 | AC1-7 | TC-INT-018, TC-INT-019, TC-INT-020, TC-INT-021, TC-INT-022, TC-INT-023 | Specs written, pending implementation |
 
-**Coverage:** 0/24 ACs have test coverage.
+**Coverage:** 7/31 ACs have test coverage (24 pre-existing stories still have no tests; all 7 ACs of US-BROW-005 covered by 6 new TC-INT specs that will run against the wpa-mcp:ci image once the feature is implemented).


### PR DESCRIPTION
## Summary

- Two new env vars — `WPA_MCP_BROWSER_LANG` (BCP-47 locale) and `WPA_MCP_BROWSER_TZ` (IANA timezone) — flow into the embedded `@playwright/mcp` subprocess's Chromium `contextOptions` via a generated `--config` JSON.
- When **either** is set, `docker/entrypoint.sh` emits `/tmp/playwright-mcp-config.json` and appends `--config` to the launch. When **both** are unset, no file is generated and no flag is appended — the launch is byte-identical to before (regression-guarded by **TC-INT-021**).
- Implementation lives entirely in container launch wiring (`docker/entrypoint.sh`, `docker/run.sh`, `deploy/wpa-mcp.service`, `.env.example`, `README.md`). No `src/` changes.

## Why the mechanism differs from issue #47

The issue proposed `--browser-arg=--lang=<value>`. That flag **does not exist** on the pinned `@playwright/mcp@0.0.70` (`playwright-mcp --help` lists no `--browser-arg`). What the version does expose is `--config <path>` accepting a `browser.contextOptions` object. Playwright's `BrowserContextOptions.locale` documents that it sets `navigator.language`, the `Accept-Language` header, AND `Intl` formatting in one stroke; `timezoneId` covers `Intl.DateTimeFormat`. One mechanism, all three issue ACs, upstream-supported schema.

POC verified all three observable effects on the running container before any code was written.

## Limitations (documented)

- **Bind at container start.** `contextOptions` are applied at Chromium context creation. Changing either env var mid-life requires `make docker-restart`.
- **Browser scope only.** Container shell `LANG`, `date` output, and log timestamps are unchanged. Full system locale is out of scope (would need the `locales` apt package + `locale-gen`).
- **Invalid locale strings are silently accepted** by Chromium (no validation). Invalid timezone IDs throw at context creation, surfaced as `isError` on first `browser_navigate` (covered by **TC-INT-022**).

## Workflow

Followed the project's PRD → user-stories → test-cases → implementation chain (CLAUDE.md):

- **PRD:** `docs/design/14_Browser_Locale_Timezone_Design.md`
- **User story:** `docs/user-stories/42_Browser_Stories.md` (new US-BROW-005 with 7 ACs)
- **Test specs:** `cicd/tests/testcases/integration/TC-INT-018..023.yml` + `cicd/tests/src/echo-server.mjs` helper
- **Implementation:** entrypoint + run.sh + systemd + .env + README

Commit split is deliberate — `962980e` is spec-time (tests would fail), `d3f97f5` is implementation (tests pass).

## Test plan

- [x] `npm run build` — TypeScript compiles
- [x] `docker build -t wpa-mcp:ci -f docker/Dockerfile .` — image builds
- [x] `npx tsx cicd/tests/src/cli.ts run --suite integration --no-llm` — **25/25 pass** (17 pre-existing + 6 new):
  - **TC-INT-018** Full config (AC1 + AC3) — 7.5s
  - **TC-INT-019** Accept-Language echo (AC2) — 8.7s
  - **TC-INT-020** Partial config (AC4) — 7.5s
  - **TC-INT-021** Default regression (AC5) — 5.4s
  - **TC-INT-022** Invalid TZ error (AC7) — 6.4s
  - **TC-INT-023** README docs (AC6) — 5ms
- [ ] Manual smoke against real captive portal (post-merge)
- [ ] Reviewer to confirm doc cross-references resolve

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)