### PR TITLE
docs: bootstrap session_summaries directory

### DIFF
--- a/docs/session_summaries/2026-05-12_0148_summary.md
+++ b/docs/session_summaries/2026-05-12_0148_summary.md
@@ -1,0 +1,53 @@
+---
+date: 2026-05-12
+session_id: 20260512-0148
+workflow_patterns: [Design, Meta]
+outcome: Completed
+scale: Long
+commands_used: [/prd, /user-stories, /session-summary]
+mcp_categories: [wpa-mcp (wifi tools), wpa-playwright (browser tools)]
+---
+
+## Goal
+
+Implement a new container-level configuration feature for an MCP server (env-var driven browser i18n), from issue triage through merged PR, using the project's PRD → user-stories → test-cases → implementation chain.
+
+## Artifacts
+
+- Design doc: 1 created
+- User story file: 1 modified (1 new story with 7 ACs)
+- YAML test cases: 6 created
+- Test helper script: 1 created
+- Shell scripts modified: 2 (entrypoint + run script)
+- Systemd-related files modified: 2
+- Config files modified: 2 (.env, .env.example)
+- README updates: 2 (project README + docs index)
+- Commits: 4 (spec, impl, doc-fix, gap-fix), 1 PR merged
+
+## Workflow
+
+Started with a GitHub issue. Investigated the issue's proposed mechanism, discovered the cited CLI flag didn't exist on the pinned upstream version, and pivoted via a POC to a config-file mechanism. Drove the project's full TDD chain: PRD with seven decisions, user story with mapped test cases, six executable YAML tests written before code, then implementation. Real-world e2e validation through the production startup path (env file → docker run → entrypoint config generation → browser → real internet site) caught a missing plumbing file that the PRD's "Files to Modify" table had omitted; fixed and pushed to the same PR before merge.
+
+## Friction Points
+
+- Misread user's architectural critique multiple times; user had to insist "understand the project, then talk to me" before agent re-grounded. Wasted ~4 messages theorizing before re-reading the codebase.
+- Initial "Files to Modify" table missed a sibling startup script that had its own `docker run` block — only caught at end-to-end production-path validation, not at design or test-spec time.
+- Test-pattern regex assumed unescaped JSON quotes; the helper script wraps responses in `JSON.stringify(..., null, 2)` which escapes inner quotes. Required pre-implementation review to catch.
+- POC subprocess restarts caused session-not-found errors that were briefly attributed to architecture rather than the act of restarting. Confusing diagnostic until reconstructed.
+- Wireless phy did not auto-return to host after container stop (driver quirk on Intel WiFi 6). User opted to reboot rather than reload the kernel module.
+- Investigation of a separate user-reported reliability concern ("browser dies after network change, even on roam") couldn't be reproduced in this session despite multiple disconnect/reconnect cycles — shelved without resolution.
+
+## Patterns Detected
+
+- **Repeated sequence:** After each artifact (PRD, user story, test specs, PR), agent paused for user-requested review and applied a small set of corrections before moving on. → Candidate for: structured "self-review checklist" before declaring an artifact done (saves a review round-trip).
+- **Workflow gap:** "Files to Modify" tables drift from reality when there are sibling files doing the same job (two startup scripts with parallel `docker run` blocks). → Suggestion: when listing files in a PRD, agent should `rg` for the same docker-run / shell-exec block elsewhere in the repo and either include or explicitly exclude each sibling.
+- **Workflow gap:** Test-spec pattern matching against tool output didn't account for nested JSON encoding. → Suggestion: when writing pattern-match tests for MCP tool responses, capture an example real output first, then write the pattern.
+- **Efficiency win:** POC against the running system *before* committing to a mechanism caught a wrong premise in the source issue. Saved a wasted implementation cycle.
+- **Efficiency win:** Probing the actual upstream error string (running a temp subprocess with bad config) before writing the assertion for an error-case test, instead of guessing the wording. Made the test precise without flake risk.
+- **Efficiency win:** End-to-end validation through the real production path (not just the isolated TDD container) caught a real gap that unit-level tests would have missed indefinitely.
+
+## Signals for /evolve
+
+- Recurring lesson: agent over-theorizes when user offers an architectural hypothesis instead of immediately mapping the hypothesis to specific files and verifying. Worth a CLAUDE.md note: "When user says 'I think X is the problem', open the relevant files and confirm/refute against code before generating analysis."
+- Recurring lesson: PRD's "Files to Modify" tables need a "find siblings" pass — repos commonly have duplicate plumbing (two `docker run` blocks, two startup paths). A grep-driven sibling search would catch this.
+- Recurring lesson: pattern-matching tests against JSON-wrapped tool outputs are a known foot-gun. Suggest a `/ci-testcase` lint that warns on regexes assuming raw `{"key":"value"}` shape.

--- a/docs/session_summaries/patterns.md
+++ b/docs/session_summaries/patterns.md
@@ -1,0 +1,31 @@
+# Session Patterns
+
+Last updated: 2026-05-12
+Total sessions recorded: 1
+
+## Workflow Distribution
+
+| Pattern | Count | Last Seen |
+|---------|-------|-----------|
+| Design  | 1     | 2026-05-12 |
+| Meta    | 1     | 2026-05-12 |
+
+## Recurring Friction Points
+
+| Friction Point | Occurrences | First Seen | Last Seen | Status |
+|---------------|-------------|------------|-----------|--------|
+| Agent over-theorizes on architectural hypotheses instead of grounding in code | 1 | 2026-05-12 | 2026-05-12 | Open |
+| PRD "Files to Modify" misses sibling files that share a code pattern (e.g., parallel `docker run` blocks in two startup scripts) | 1 | 2026-05-12 | 2026-05-12 | Open |
+| Test pattern regexes assume raw JSON when tool output is JSON-wrapped via `JSON.stringify(..., null, 2)` (escapes quotes) | 1 | 2026-05-12 | 2026-05-12 | Open |
+| POC subprocess restarts produced confusing session-not-found errors attributed to architecture rather than restart | 1 | 2026-05-12 | 2026-05-12 | Open |
+| Wireless phy didn't auto-return to host after container stop (Intel WiFi 6 / iwlwifi quirk) | 1 | 2026-05-12 | 2026-05-12 | Open |
+| Cross-session reliability concern (browser failure across wifi state changes / roaming) not reproducible in controlled session | 1 | 2026-05-12 | 2026-05-12 | Open |
+
+## Improvement Candidates
+
+| Candidate | Evidence Count | Suggestion | Status |
+|-----------|---------------|------------|--------|
+| Self-review checklist before declaring an artifact done | 1 | Insert a one-page checklist (factual accuracy, link validity, sibling-file sweep, pattern correctness) into the `/prd`, `/user-stories`, and `/ci-testcase` skill outputs before the user is asked to review | Proposed |
+| "Find siblings" pass in `/prd` Files to Modify | 1 | When the PRD lists a file with a noteworthy code pattern (e.g., `docker run`, shell exec, env var passthrough), grep the repo for the same pattern elsewhere and either include or explicitly exclude each match | Proposed |
+| Pattern-match lint for `/ci-testcase` YAMLs | 1 | When generating regex `expectPatterns` against MCP tool outputs, agent should first capture one real example output and then derive the regex from observed structure (not assumed structure) | Proposed |
+| CLAUDE.md note: ground hypotheses before analyzing | 1 | Add a sub-section under "Doing tasks": "When the user offers an architectural hypothesis, open the relevant files and confirm or refute against code before generating analysis. Avoid theorizing past one round-trip." | Proposed |


### PR DESCRIPTION
## Summary

Adds `docs/session_summaries/` with the first entry, capturing the issue #47 / PR #48 working session per the `/session-summary` command protocol.

- `2026-05-12_0148_summary.md` — privacy-checked structural summary: Design + Meta workflow patterns, six friction points, six efficiency observations, three candidate signals for `/evolve`.
- `patterns.md` — aggregate index (1 session, workflow-distribution table, recurring-friction table, four improvement-candidate proposals).

## Why commit (vs. local-only)

The `/session-summary` command's default is local-only. Overriding for this repo because: (a) the patterns are useful to surface during PR reviews; (b) future `/evolve` runs against this repo can read the patterns directly from `main`; (c) survives disk wipes.

If we later decide some entries shouldn't be in git, we can `.gitignore` specific filenames; the directory itself stays tracked.

## Test plan

- [x] `cat docs/session_summaries/2026-05-12_0148_summary.md` renders clean (frontmatter + sections per the template)
- [x] Privacy check: no real ticket IDs (issue #47 / PR #48 are public on this repo, OK), no credentials, no internal hostnames, no real person names
- [ ] Reviewer to confirm whether ongoing summaries should also be committed or only the bootstrap entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)