### PR TITLE
fix: route MCP replies via eth0 to avoid asymmetric routing (#51)

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -19,6 +19,10 @@ set -euo pipefail
 
 IFACE="${WIFI_INTERFACE:-wlan0}"
 
+# Capture the bridge gateway before we (optionally) delete the default route;
+# the policy-routing rule below needs it to send MCP replies back via eth0.
+BRIDGE_GW="$(ip route show default 2>/dev/null | awk '/dev eth0/ {print $3; exit}')"
+
 # Delete Docker bridge default route so WiFi becomes the sole default
 # when dhclient runs during wifi_connect. The bridge subnet route is
 # preserved for MCP client access via Docker port forwarding.
@@ -27,6 +31,22 @@ if [[ "${KEEP_BRIDGE_DEFAULT:-}" != "1" ]]; then
     echo "entrypoint: deleting bridge default route"
     sudo ip route del default 2>/dev/null || true
   fi
+fi
+
+# Source-based reply routing for inbound MCP traffic. Without this, when the
+# joined WiFi LAN shares a subnet with the docker host's other interface (e.g.
+# host wired and container WiFi both on 192.168.5.0/24), the kernel matches
+# `192.168.5.0/24 dev wlp0s20f3` for the reply and sends SYN-ACKs out the
+# WiFi side instead of back via eth0. Remote MCP clients then see TCP
+# timeouts. By scoping the override to packets whose *source* is our eth0
+# address, WiFi-originated traffic (src = wlp0s20f3 IP) is untouched.
+ETH0_IP="$(ip -4 -o addr show eth0 2>/dev/null | awk '{print $4}' | cut -d/ -f1)"
+if [[ -n "$ETH0_IP" && -n "$BRIDGE_GW" ]]; then
+  echo "entrypoint: installing reply-path policy route (src=$ETH0_IP via $BRIDGE_GW)"
+  sudo ip route add default via "$BRIDGE_GW" dev eth0 table 100 2>/dev/null || true
+  sudo ip rule add from "$ETH0_IP" table 100 priority 100 2>/dev/null || true
+else
+  echo "entrypoint: skipping reply-path policy route (eth0_ip=$ETH0_IP bridge_gw=$BRIDGE_GW)"
 fi
 
 # Bring WiFi interface up if present (phy may be moved in after start)


### PR DESCRIPTION
Closes #51

## Problem

Remote MCP clients hitting `http://<docker-host-IP>:3000/mcp` from another machine on the LAN see TCP timeouts. Server is healthy and `/health` works locally. Originally suspected an MCP concurrency race (#50) — that was a misdiagnosis.

Reproduced and traced with `tcpdump`:

```
192.168.5.176.33670 > 172.17.0.2:3000  [SYN]
192.168.5.176.33670 > 172.17.0.2:3000  [SYN]  (retransmit)
192.168.5.176.33670 > 172.17.0.2:3000  [SYN]  (retransmit)
```

SYNs arrive at the container after DNAT but no SYN-ACK comes back. Root cause: when the container replies to `192.168.5.176`, the kernel matches `192.168.5.0/24 dev wlp0s20f3` (because the joined WiFi LAN shares the docker host's /24) and the reply goes out the WiFi side instead of back via the docker bridge.

Container routing table at fault:

```
default via 192.168.5.1 dev wlp0s20f3 
172.17.0.0/16 dev eth0 proto kernel scope link src 172.17.0.2 
192.168.5.0/24 dev wlp0s20f3 proto kernel scope link src 192.168.5.132 
```

## Fix

Source-based policy routing keyed on the container's bridge IP:

```
ip route add default via $BRIDGE_GW dev eth0 table 100
ip rule  add from $ETH0_IP table 100 priority 100
```

Only matches replies whose *source* is the bridge IP, so WiFi-originated traffic (src = `wlp0s20f3` IP) is untouched. No iptables/nftables needed.

## Verification

Same fix injected by hand into the running container's netns earlier in the investigation; `curl http://192.168.5.176:3000/health` from the host immediately returned the OK response. Rebuilt the image so the new entrypoint installs the rules at startup — verified the rule survives `make docker-stop && sudo make docker-start`.

## Why it's safe

- Only fires when the joined WiFi subnet overlaps the docker host's other subnet (the bug condition). Otherwise the rule simply doesn't match outbound packets because their `src` is the WiFi IP, not the bridge IP.
- Adds one rule and one table; removes nothing.
- Test plan below — needs a real remote client to confirm end-to-end in the user's environment.

## Test plan

- [ ] `make docker-stop && sudo make docker-start`
- [ ] On a *different host* on the LAN: `curl http://192.168.5.176:3000/health` returns OK.
- [ ] `wifi_connect` to a WLAN still works.
- [ ] Browsing via `playwright-mcp` (which runs in the same netns) still reaches captive portals on the WLAN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)