### PR TITLE
fix: honor browser locale/tz env vars in browser_run_script

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,8 +325,10 @@ Copy `.env.example` to `.env`. Key settings:
 | `WIFI_INTERFACE` | wlan0 | WiFi interface name |
 | `WPA_CONFIG_PATH` | /etc/wpa_supplicant/wpa_supplicant.conf | wpa_supplicant config |
 | `WPA_DEBUG_LEVEL` | 2 | Debug verbosity (1-3) |
-| `WPA_MCP_BROWSER_LANG` | _(unset)_ | BCP-47 locale for the in-container browser, e.g. `pt-PT`. Sets `navigator.language`, the `Accept-Language` header, and locale-aware `Intl` formatting. Read at container start — changing requires `make docker-restart`. |
-| `WPA_MCP_BROWSER_TZ` | _(unset)_ | IANA timezone for the in-container browser, e.g. `Europe/Lisbon`. Sets `Intl.DateTimeFormat().resolvedOptions().timeZone`. Browser-scoped only — does not change the container shell clock or log timestamps. Read at container start. |
+| `WPA_MCP_BROWSER_LANG` | _(unset)_ | BCP-47 locale for the in-container browser, e.g. `pt-PT`. Sets `navigator.language`, the `Accept-Language` header, and locale-aware `Intl` formatting. Applies to `mcp__wpa-playwright__*` and `browser_run_script`. Read at container start — changing requires `make docker-restart`. |
+| `WPA_MCP_BROWSER_TZ` | _(unset)_ | IANA timezone for the in-container browser, e.g. `Europe/Lisbon`. Sets `Intl.DateTimeFormat().resolvedOptions().timeZone`. Browser-scoped only — does not change the container shell clock or log timestamps. Applies to `mcp__wpa-playwright__*` and `browser_run_script`. Read at container start. |
+
+`browser_open` is **not** affected by these variables — it spawns the server host's default browser, which has its own locale settings.
 
 For i18n captive-portal testing, see [docs/design/14_Browser_Locale_Timezone_Design.md](docs/design/14_Browser_Locale_Timezone_Design.md).
 

--- a/docs/user-stories/42_Browser_Stories.md
+++ b/docs/user-stories/42_Browser_Stories.md
@@ -19,6 +19,10 @@ As a user, I want to open a URL in the system browser so that I can manually int
 2. Invalid URL returns informative error
 3. Returns success message with the opened URL
 
+### Notes
+
+- **Out of scope: locale/timezone control.** `browser_open` spawns the server host's default browser via the `open` npm package; that browser is not inside the container's netns and is not configured by `WPA_MCP_BROWSER_LANG` / `WPA_MCP_BROWSER_TZ`. For i18n testing inside the container, use `browser_run_script` or the proxied `mcp__wpa-playwright__*` tools instead (US-BROW-005).
+
 ### Test Mapping
 
 | AC# | Test Case | Status |
@@ -152,7 +156,7 @@ As a user driving a captive portal through the proxied `wpa-playwright` MCP, I w
 - **Non-functional constraint — bind at container start.** Playwright's `contextOptions` are applied at Chromium context creation, which is the first `browser_navigate` after the `playwright-mcp` subprocess launches. Changing either env var mid-life has no effect until `make docker-restart` (or equivalent). This is documented as a known limitation, not a bug.
 - **Browser scope only.** These env vars affect *only* the headless Chromium that `playwright-mcp` spawns. They do **not** change the container shell's `LANG` / `LC_ALL`, the output of `date`, or the timestamps in `/tmp/wpa_supplicant_*.log`. A full system locale is out of scope (would require the `locales` apt package + `locale-gen`).
 - **Invalid locale strings are silently accepted.** Chromium does not validate `navigator.language` content; an unknown locale (e.g. `garbage`) is forwarded as-is to the `Accept-Language` header and `navigator.language`. Only invalid timezone IDs throw at context creation (covered by AC7).
-- The implementation lives entirely in `docker/entrypoint.sh` plus passthrough plumbing in `docker/run.sh`, `deploy/wpa-mcp.service`, and `.env.example`. No `src/` changes.
+- The proxied `@playwright/mcp` surface is configured via `docker/entrypoint.sh` + passthrough plumbing in `docker/run.sh`, `deploy/wpa-mcp.service`, and `.env.example`. The in-process `browser_run_script` surface (`src/lib/playwright-runner.ts`) reads the same two env vars and passes them to `browser.newContext({ locale, timezoneId })` (issue #53). `browser_open` (US-BROW-001) is **not** covered — it spawns a browser on the server host, outside the container.
 
 ### Test Mapping
 

--- a/src/lib/playwright-runner.ts
+++ b/src/lib/playwright-runner.ts
@@ -76,7 +76,16 @@ export async function runScript(
       args: ['--no-sandbox', '--disable-setuid-sandbox'],
     });
 
-    const context = await browser.newContext();
+    // Same env-var contract as the embedded @playwright/mcp subprocess
+    // (docker/entrypoint.sh) — both browser surfaces should localize the same
+    // way, per US-BROW-005.
+    const contextOptions: Parameters<Browser['newContext']>[0] = {};
+    const browserLocale = process.env.WPA_MCP_BROWSER_LANG;
+    const browserTimezone = process.env.WPA_MCP_BROWSER_TZ;
+    if (browserLocale) contextOptions.locale = browserLocale;
+    if (browserTimezone) contextOptions.timezoneId = browserTimezone;
+
+    const context = await browser.newContext(contextOptions);
     const page = await context.newPage();
 
     // Set default timeout


### PR DESCRIPTION
## Summary

- Fixes issue #53: PR #48 added `WPA_MCP_BROWSER_LANG` / `WPA_MCP_BROWSER_TZ`, but only wired them into the proxied `@playwright/mcp` subprocess. The in-process surface used by `browser_run_script` (`src/lib/playwright-runner.ts`) still called `browser.newContext()` with no options, so any custom Playwright script saw default Chromium locale.
- `runScript` now reads both env vars and passes them to `newContext` as `{ locale, timezoneId }`. When both are unset, `contextOptions = {}` — behavior is byte-equivalent to before.
- README and US-BROW-001 / US-BROW-005 updated to make clear that `browser_open` is **not** covered (it spawns the server host's browser, outside the container) and the two affected surfaces are `mcp__wpa-playwright__*` plus `browser_run_script`.

## Why the gap existed

PR #48's description explicitly said "Implementation lives entirely in container launch wiring … No `src/` changes." That kept the change small but missed `playwright-runner.ts`, which has its own Playwright launch.

## Verification

- `npm run build` — TypeScript compiles cleanly.
- Proxied `@playwright/mcp` surface already verified correct before this change (`navigator.language === 'pt-PT'`, `Accept-Language: pt-PT`, timezone `Europe/Lisbon`, `google.com` returns `<html lang=\"pt-PT\">`).
- The contract for the in-process surface is provably the same: `process.env.WPA_MCP_BROWSER_LANG` → `contextOptions.locale`, `process.env.WPA_MCP_BROWSER_TZ` → `contextOptions.timezoneId`. Playwright's `BrowserContextOptions.locale` is documented to set `navigator.language`, `Accept-Language`, and `Intl` formatting in one stroke.

## Why no integration test

A TC-INT-024 was drafted (\`browser_run_script\` + echo-server end-to-end) but cannot pass in the current Docker image due to a **separate, pre-existing** chromium-revision mismatch — filed as **#54**. The app's `playwright-core@1.56.1` expects chromium revision `1194`; the Dockerfile only installs revision `1217` via `@playwright/mcp`'s bundled core. So `browser_run_script` returns `success: false / Executable doesn't exist at /ms-playwright/chromium_headless_shell-1194/...` for any script, locale-fix or not. Once #54 lands, the TC can be re-introduced unchanged.

## Test plan

- [x] `npm run build` — passes
- [x] `docker build -t wpa-mcp:ci -f docker/Dockerfile .` — passes
- [x] Read-through: `git diff src/lib/playwright-runner.ts` is the entire functional change (12 lines)
- [ ] End-to-end test deferred behind #54

Closes #53
Follow-up: #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)