### PR TITLE
Observability for /playwright-mcp + /mcp, plus two bugs surfaced (#56)

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -121,10 +121,19 @@ EOF
   PW_CONFIG_FLAG="--config $PW_CONFIG_PATH"
 fi
 
+# Observability: surface playwright-mcp output to the container's stdout
+# (so `docker logs wpa-mcp` shows it) AND keep a local copy in
+# /tmp/playwright-mcp.log. `> >(tee FILE)` uses process substitution so the
+# subprocess's stdout/stderr fan out to both; `$!` still captures the
+# playwright-mcp pid (not tee's). DEBUG=pw:browser*,pw:protocol* turns on
+# Playwright's own page-crash / target-closed / disconnect events so a
+# browser context dying mid-captive-portal is visible instead of silent.
+#
 # NB: $PW_CONFIG_FLAG is intentionally unquoted so that when empty it
 # expands to zero arguments, and when set it word-splits into two args
 # (`--config` and the path). The path is hardcoded so word-splitting is
 # safe; values from the env vars only appear inside the JSON, not the flag.
+DEBUG="${WPA_MCP_PLAYWRIGHT_DEBUG:-pw:browser*}" \
 playwright-mcp \
   --headless \
   --browser chromium \
@@ -134,7 +143,7 @@ playwright-mcp \
   --port "${PLAYWRIGHT_MCP_PORT}" \
   --host 127.0.0.1 \
   $PW_CONFIG_FLAG \
-  > /tmp/playwright-mcp.log 2>&1 &
+  > >(tee /tmp/playwright-mcp.log) 2>&1 &
 PLAYWRIGHT_MCP_PID=$!
 
 # Sanity-check: wait briefly for playwright-mcp to bind so a failure to

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -125,9 +125,10 @@ fi
 # (so `docker logs wpa-mcp` shows it) AND keep a local copy in
 # /tmp/playwright-mcp.log. `> >(tee FILE)` uses process substitution so the
 # subprocess's stdout/stderr fan out to both; `$!` still captures the
-# playwright-mcp pid (not tee's). DEBUG=pw:browser*,pw:protocol* turns on
-# Playwright's own page-crash / target-closed / disconnect events so a
-# browser context dying mid-captive-portal is visible instead of silent.
+# playwright-mcp pid (not tee's). DEBUG=pw:browser* turns on Playwright's
+# own page-crash / target-closed / disconnect events so a browser context
+# dying mid-captive-portal is visible instead of silent. (pw:protocol* is
+# omitted on purpose — it logs every CDP frame and drowns the signal.)
 #
 # NB: $PW_CONFIG_FLAG is intentionally unquoted so that when empty it
 # expands to zero arguments, and when set it word-splits into two args

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -106,7 +106,11 @@ fi
 # --- Start container (bridge network, port forwarded) ---
 
 echo "Starting container '$CONTAINER_NAME' from image '$IMAGE'..."
-docker run --rm -d \
+# --init: run tini as PID 1 so orphaned chromium/sudo children get reaped
+# instead of accumulating as zombies. The playwright-mcp subprocess can
+# spawn many short-lived chromium processes during captive-portal flows;
+# without a reaper they pile up under PID 1 (node) and mask real signals.
+docker run --rm -d --init \
   --name "$CONTAINER_NAME" \
   --cap-add NET_ADMIN \
   --cap-add NET_RAW \

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,6 @@
 import "dotenv/config";
+import crypto from "node:crypto";
+import type { ClientRequest, IncomingMessage, ServerResponse } from "node:http";
 import express, { Request, Response } from "express";
 import {
   createProxyMiddleware,
@@ -62,6 +64,90 @@ registerBrowserTools(mcpServer);
 registerConnectivityTools(mcpServer);
 registerCredentialTools(mcpServer);
 
+// Structured one-line JSON logger. Keeps a single shape across req / res /
+// error so log lines for the same call can be joined on req_id when triaging
+// "agent stuck in X" or captive-portal sessions.
+const logEvent = (
+  level: "info" | "warn" | "error",
+  msg: string,
+  ctx: Record<string, unknown>,
+): void => {
+  const line = JSON.stringify({
+    ts: new Date().toISOString(),
+    level,
+    msg,
+    ...ctx,
+  });
+  if (level === "error") console.error(line);
+  else console.log(line);
+};
+
+// Per-request scratch slots stashed on the express req object. Symbols
+// avoid colliding with any field http-proxy-middleware or express attach.
+const REQ_ID = Symbol("wpaReqId");
+const REQ_START_MS = Symbol("wpaStartMs");
+
+type AnnotatedReq = IncomingMessage & {
+  body?: unknown;
+  [REQ_ID]?: string;
+  [REQ_START_MS]?: number;
+};
+
+// Pull `method` and (for tools/call) `params.name` out of a JSON-RPC body.
+// Without `tool_name`, every browser_*/wifi_* call shows up as a generic
+// "tools/call" line and a stuck agent is indistinguishable from a working one.
+const extractJsonrpcInfo = (
+  body: unknown,
+): { method?: string; toolName?: string } => {
+  if (!body || typeof body !== "object") return {};
+  const methodVal = (body as { method?: unknown }).method;
+  const method = typeof methodVal === "string" ? methodVal : undefined;
+  let toolName: string | undefined;
+  if (method === "tools/call") {
+    const params = (body as { params?: unknown }).params;
+    if (params && typeof params === "object") {
+      const nameVal = (params as { name?: unknown }).name;
+      if (typeof nameVal === "string") toolName = nameVal;
+    }
+  }
+  return { method, toolName };
+};
+
+// Express middleware: tag every /mcp request with a req_id, log entry on
+// arrival and exit on response finish. Same shape as the /playwright-mcp
+// proxy logs so a single `grep req_id=...` joins both endpoints.
+const logMcpMiddleware = (
+  req: Request,
+  res: Response,
+  next: () => void,
+): void => {
+  const annotated = req as unknown as AnnotatedReq;
+  const reqId = crypto.randomBytes(4).toString("hex");
+  annotated[REQ_ID] = reqId;
+  annotated[REQ_START_MS] = Date.now();
+
+  const { method: jsonrpcMethod, toolName } = extractJsonrpcInfo(req.body);
+
+  logEvent("info", "wpa-mcp req", {
+    req_id: reqId,
+    http_method: req.method,
+    jsonrpc_method: jsonrpcMethod,
+    tool_name: toolName,
+  });
+
+  res.on("finish", () => {
+    logEvent("info", "wpa-mcp res", {
+      req_id: reqId,
+      status: res.statusCode,
+      elapsed_ms: Date.now() - (annotated[REQ_START_MS] ?? Date.now()),
+    });
+  });
+
+  next();
+};
+
+app.use("/mcp", logMcpMiddleware);
+
 // MCP endpoint using Streamable HTTP Transport
 app.post("/mcp", async (req: Request, res: Response) => {
   try {
@@ -76,7 +162,11 @@ app.post("/mcp", async (req: Request, res: Response) => {
     await mcpServer.connect(transport);
     await transport.handleRequest(req, res, req.body);
   } catch (error) {
-    console.error("MCP request error:", error);
+    const reqId = (req as unknown as AnnotatedReq)[REQ_ID];
+    logEvent("error", "wpa-mcp handler error", {
+      req_id: reqId,
+      error: error instanceof Error ? error.message : String(error),
+    });
     if (!res.headersSent) {
       res.status(500).json({ error: "Internal server error" });
     }
@@ -100,6 +190,54 @@ app.delete("/mcp", (_req: Request, res: Response) => {
     id: null,
   });
 });
+
+const logProxyReq = (
+  proxyReq: ClientRequest,
+  req: IncomingMessage,
+  _res: ServerResponse,
+): void => {
+  const annotated = req as AnnotatedReq;
+  const reqId = crypto.randomBytes(4).toString("hex");
+  annotated[REQ_ID] = reqId;
+  annotated[REQ_START_MS] = Date.now();
+
+  const { method: jsonrpcMethod, toolName } = extractJsonrpcInfo(annotated.body);
+
+  logEvent("info", "playwright-mcp proxy req", {
+    req_id: reqId,
+    http_method: req.method,
+    jsonrpc_method: jsonrpcMethod,
+    tool_name: toolName,
+  });
+
+  // Echo the id upstream so the subprocess logs (once we wire DEBUG=pw:*)
+  // can be correlated with proxy lines.
+  proxyReq.setHeader("x-wpa-req-id", reqId);
+
+  // Preserve existing body-forwarding behaviour for POSTs.
+  fixRequestBody(proxyReq, req as Request);
+};
+
+const logProxyRes = (proxyRes: IncomingMessage, req: IncomingMessage): void => {
+  const annotated = req as AnnotatedReq;
+  const startMs = annotated[REQ_START_MS];
+  logEvent("info", "playwright-mcp proxy res", {
+    req_id: annotated[REQ_ID],
+    status: proxyRes.statusCode,
+    elapsed_ms: typeof startMs === "number" ? Date.now() - startMs : undefined,
+  });
+};
+
+const logProxyError = (err: Error, req: IncomingMessage): void => {
+  const annotated = req as AnnotatedReq;
+  const startMs = annotated[REQ_START_MS];
+  logEvent("error", "playwright-mcp proxy error", {
+    req_id: annotated[REQ_ID],
+    error: err.message,
+    code: (err as NodeJS.ErrnoException).code,
+    elapsed_ms: typeof startMs === "number" ? Date.now() - startMs : undefined,
+  });
+};
 
 // Reverse proxy to the in-container Microsoft Playwright MCP server.
 //
@@ -125,58 +263,22 @@ const playwrightMcpPort = process.env.PLAYWRIGHT_MCP_PORT || "8931";
 // check on the Host header and rejects anything else.
 const playwrightMcpTarget = `http://localhost:${playwrightMcpPort}`;
 
+const initializeResponseInterceptor = responseInterceptor(
+  async (responseBuffer, proxyRes, req, _res) => {
+    logProxyRes(proxyRes as IncomingMessage, req as IncomingMessage);
+    return await rewriteInitializeBody(responseBuffer, proxyRes);
+  },
+);
+
 const playwrightInitializeProxy = createProxyMiddleware({
   target: playwrightMcpTarget,
   changeOrigin: true,
   pathRewrite: () => "/mcp",
   selfHandleResponse: true,
   on: {
-    proxyReq: fixRequestBody,
-    proxyRes: responseInterceptor(
-      async (responseBuffer, proxyRes, _req, _res) => {
-        const contentType = String(proxyRes.headers["content-type"] || "");
-        const body = responseBuffer.toString("utf8");
-
-        // `serverInfo` in result marks an `initialize` JSON-RPC response.
-        const injectIfInitialize = (jsonStr: string): string | null => {
-          try {
-            const obj = JSON.parse(jsonStr);
-            if (obj?.result?.serverInfo) {
-              obj.result.instructions = WPA_PLAYWRIGHT_INSTRUCTIONS;
-              return JSON.stringify(obj);
-            }
-          } catch {
-            /* not JSON — ignore */
-          }
-          return null;
-        };
-
-        // Case 1: plain JSON body (application/json).
-        if (contentType.includes("application/json")) {
-          const rewritten = injectIfInitialize(body);
-          return rewritten ?? responseBuffer;
-        }
-
-        // Case 2: SSE body (text/event-stream) — MCP Streamable HTTP can
-        // return results framed as "event: message\ndata: <json>\n\n".
-        // Inspect every `data:` line; rewrite only the one whose JSON
-        // matches the initialize marker. The `g` flag is required so
-        // the callback sees each line even when the payload has multiple
-        // events (heartbeats, batched notifications, etc.).
-        if (contentType.includes("text/event-stream")) {
-          const rewritten = body.replace(
-            /^data: (.*)$/gm,
-            (match, dataJson: string) => {
-              const newJson = injectIfInitialize(dataJson);
-              return newJson ? `data: ${newJson}` : match;
-            },
-          );
-          return rewritten === body ? responseBuffer : rewritten;
-        }
-
-        return responseBuffer;
-      },
-    ),
+    proxyReq: logProxyReq,
+    proxyRes: initializeResponseInterceptor,
+    error: logProxyError,
   },
 });
 
@@ -186,9 +288,61 @@ const playwrightStreamingProxy = createProxyMiddleware({
   pathRewrite: () => "/mcp",
   // No selfHandleResponse — responses stream through naturally.
   on: {
-    proxyReq: fixRequestBody,
+    proxyReq: logProxyReq,
+    proxyRes: logProxyRes,
+    error: logProxyError,
   },
 });
+
+// Extracted from the inline interceptor so the proxy declaration above stays
+// scannable. Same behaviour as before: rewrite the `initialize` JSON-RPC
+// response (plain JSON or SSE-framed) to inject `result.instructions`.
+async function rewriteInitializeBody(
+  responseBuffer: Buffer,
+  proxyRes: IncomingMessage,
+): Promise<Buffer | string> {
+  const contentType = String(proxyRes.headers["content-type"] || "");
+  const body = responseBuffer.toString("utf8");
+
+  // `serverInfo` in result marks an `initialize` JSON-RPC response.
+  const injectIfInitialize = (jsonStr: string): string | null => {
+    try {
+      const obj = JSON.parse(jsonStr);
+      if (obj?.result?.serverInfo) {
+        obj.result.instructions = WPA_PLAYWRIGHT_INSTRUCTIONS;
+        return JSON.stringify(obj);
+      }
+    } catch {
+      /* not JSON — ignore */
+    }
+    return null;
+  };
+
+  // Case 1: plain JSON body (application/json).
+  if (contentType.includes("application/json")) {
+    const rewritten = injectIfInitialize(body);
+    return rewritten ?? responseBuffer;
+  }
+
+  // Case 2: SSE body (text/event-stream) — MCP Streamable HTTP can
+  // return results framed as "event: message\ndata: <json>\n\n".
+  // Inspect every `data:` line; rewrite only the one whose JSON
+  // matches the initialize marker. The `g` flag is required so
+  // the callback sees each line even when the payload has multiple
+  // events (heartbeats, batched notifications, etc.).
+  if (contentType.includes("text/event-stream")) {
+    const rewritten = body.replace(
+      /^data: (.*)$/gm,
+      (match, dataJson: string) => {
+        const newJson = injectIfInitialize(dataJson);
+        return newJson ? `data: ${newJson}` : match;
+      },
+    );
+    return rewritten === body ? responseBuffer : rewritten;
+  }
+
+  return responseBuffer;
+}
 
 app.use("/playwright-mcp", (req, res, next) => {
   // Route to buffered-and-injected proxy only when the JSON-RPC method

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,13 +135,22 @@ const logMcpMiddleware = (
     tool_name: toolName,
   });
 
-  res.on("finish", () => {
+  // Listen to BOTH `finish` (normal completion) and `close` (client dropped
+  // connection mid-response). Without `close`, a wedged tool call that the
+  // agent abandons would leave no exit line — exactly the blind spot this
+  // logging is meant to remove. Guard with `logged` so we only emit once.
+  let logged = false;
+  const logRes = () => {
+    if (logged) return;
+    logged = true;
     logEvent("info", "wpa-mcp res", {
       req_id: reqId,
       status: res.statusCode,
       elapsed_ms: Date.now() - (annotated[REQ_START_MS] ?? Date.now()),
     });
-  });
+  };
+  res.on("finish", logRes);
+  res.on("close", logRes);
 
   next();
 };

--- a/src/lib/network-check.ts
+++ b/src/lib/network-check.ts
@@ -1,6 +1,7 @@
 import { exec } from 'child_process';
 import { promisify } from 'util';
 import * as dns from 'dns';
+import * as http from 'http';
 import * as https from 'https';
 import type { PingResult, DnsResult } from '../types.js';
 
@@ -146,7 +147,7 @@ function httpGet(
   return new Promise((resolve, reject) => {
     const urlObj = new URL(url);
     const isHttps = urlObj.protocol === 'https:';
-    const httpModule = isHttps ? https : require('http');
+    const httpModule = isHttps ? https : http;
 
     const options = {
       hostname: urlObj.hostname,

--- a/src/lib/wpa-cli.ts
+++ b/src/lib/wpa-cli.ts
@@ -23,19 +23,23 @@ export class WpaCli {
     const currentStatus = await this.status();
     const isScanning = currentStatus.wpaState === "SCANNING";
 
+    let didTriggerScan = false;
     if (!isScanning) {
-      // Initiate scan
-      const scanResult = await this.run("scan");
-      if (!scanResult.includes("OK")) {
-        throw new Error(`Scan failed: ${scanResult}`);
-      }
-
-      // Brief delay for state transition
-      await new Promise((resolve) => setTimeout(resolve, 200));
+      await this.triggerScan();
+      didTriggerScan = true;
     }
 
     // Poll for scan results instead of fixed wait
-    const { found } = await this.waitForScanResults(timeoutMs);
+    let { found } = await this.waitForScanResults(timeoutMs);
+
+    // Stuck-radio recovery: if we skipped the trigger because wpa_supplicant
+    // claimed to already be SCANNING but the cache stayed empty for the full
+    // poll window, the driver is wedged (seen after disconnect + MAC change).
+    // Issue a fresh `scan` to kick it loose and poll again.
+    if (!found && !didTriggerScan) {
+      await this.triggerScan();
+      ({ found } = await this.waitForScanResults(timeoutMs));
+    }
 
     if (!found) {
       // Return empty array if no results found (not an error, just no networks)
@@ -46,6 +50,17 @@ export class WpaCli {
     // buffer (~4 KB) truncates the monolithic `scan_results` output at roughly
     // 55 BSSes, silently dropping nearby APs in dense RF environments.
     return this.fetchBssEntries();
+  }
+
+  private async triggerScan(): Promise<void> {
+    const scanResult = await this.run("scan");
+    // FAIL-BUSY = a scan is already in flight; its results will still
+    // populate the cache, so treat it as success rather than aborting.
+    if (!scanResult.includes("OK") && !scanResult.includes("FAIL-BUSY")) {
+      throw new Error(`Scan failed: ${scanResult}`);
+    }
+    // Brief delay for state transition into SCANNING
+    await new Promise((resolve) => setTimeout(resolve, 200));
   }
 
   /**


### PR DESCRIPTION
## Summary

- Structured JSON logging across **both** MCP endpoints with `req_id`, `jsonrpc_method`, `tool_name`, `status`, `elapsed_ms`. A future "agent stuck in X" report is answerable from `docker logs wpa-mcp` alone.
- Two bugs caught and fixed because the new logging made them visible: stuck-radio recovery in `wifi_scan`, and an ESM `require()` runtime crash in the captive-portal probe.

Closes #56.

## What's in here

### Observability (the substrate)

| File | Change |
|---|---|
| `src/index.ts` | Shared `extractJsonrpcInfo` helper used by both endpoints. New express middleware on `/mcp` emits `wpa-mcp req` / `wpa-mcp res` with `req_id` and `res.on('finish')` latency. Existing `/playwright-mcp` proxy hooks reuse the same helper so every `tools/call` shows the concrete tool name (`browser_navigate`, `wifi_scan`, ...) instead of a generic `"tools/call"`. |
| `docker/entrypoint.sh` | `playwright-mcp` stdout/stderr fanned to `docker logs` via `tee` while still keeping `/tmp/playwright-mcp.log`. `DEBUG=pw:browser*` enabled by default; override via `WPA_MCP_PLAYWRIGHT_DEBUG`. This is what surfaces chromium SIGSEGV/target-closed/disconnect events that would otherwise be silent. |
| `docker/run.sh` | `--init` flag so tini reaps orphaned chromium / sudo children. Pre-fix the container accumulated ~18 zombies per browser-cycle. |

### Bug fixes surfaced by the new logs

| File | Bug | Fix |
|---|---|---|
| `src/lib/wpa-cli.ts` | `wifi_scan` spins on empty `scan_results` forever after a disconnect + MAC change. wpa_supplicant claims to already be `SCANNING`, so the old code skipped issuing a fresh `scan` and just polled an empty cache. Caught because the `/tmp/wpa_supplicant_wlp0s20f3.log` showed `SCAN_RESULTS` queried every 500 ms with nothing coming back. | `scan()` now retries by force-issuing a fresh `scan` if the cache stays empty for the full poll window. New `triggerScan()` helper tolerates `FAIL-BUSY` (concurrent scan in flight is fine). |
| `src/lib/network-check.ts` | `network_check_captive` returned `error: "require is not defined"` at runtime. Package is `"type": "module"`, so `require('http')` at line 149 blew up the http (not https) probe branch. | Top-of-file `import * as http from 'http'`, then a direct ternary. |

## Test plan

- [x] `npm run build` clean
- [x] `make docker-build && sudo make docker-restart` succeeds
- [x] `wifi_scan` returns 200 networks; `docker logs` shows `wpa-mcp req tool_name=wifi_scan` + matching `wpa-mcp res status=200`
- [x] Captive-portal flow (i18n-PT-Email Email-portal sign-in) completes end-to-end without browser crash or stale-session 404, all calls visible in `docker logs` with `tool_name`
- [x] `network_check_captive` returns a meaningful error (`EAI_AGAIN` when DNS unavailable) instead of `require is not defined`
- [ ] Zombie count stays flat over a multi-hour session — observed at 2 in earlier tests, would re-verify post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)